### PR TITLE
refactor: make layouts comptime and generic, decoupling layout code and datastructure from core

### DIFF
--- a/examples/config.zon
+++ b/examples/config.zon
@@ -11,10 +11,6 @@
     // .horizontal always splits left/right, .vertical always splits top/bottom.
     // .bsp_split = .auto,
 
-    // BSP insertion target policy.
-    // .split creates a new split, .stack adds to target leaf stack.
-    // .bsp_insert_mode = .split,
-    //
     // BSP insertion point policy.
     // .focused, .first, .last, .min_depth
     // .bsp_insert_point = .focused,

--- a/src/config.zig
+++ b/src/config.zig
@@ -4,7 +4,7 @@
 
 const std = @import("std");
 const shim = @import("shim_api.zig");
-const layout_mod = @import("layout.zig");
+const tiling = @import("tiling.zig");
 const osutil = @import("osutil.zig");
 
 const log = std.log.scoped(.config);
@@ -17,12 +17,11 @@ pub const Config = struct {
     workspace_names: []const []const u8 = &.{},
     swipe: SwipeConfig = .{},
     gaps: Gaps = .{},
-    layout: layout_mod.LayoutKind = .bsp,
-    bsp_split: layout_mod.SplitMode = .auto,
-    bsp_insert_mode: layout_mod.InsertMode = .split,
-    bsp_insert_point: layout_mod.InsertionPointPolicy = .focused,
+    layout: tiling.LayoutKind = .bsp,
+    bsp_split: tiling.SplitMode = .auto,
+    bsp_insert_point: tiling.InsertionPointPolicy = .focused,
     bsp_split_ratio: f64 = 0.5,
-    new_window_split: layout_mod.InsertChild = .second,
+    new_window_split: tiling.InsertChild = .second,
 
     /// Look up the assigned workspace for a given bundle identifier.
     pub fn workspaceForApp(self: *const Config, bundle_id: []const u8) ?u8 {
@@ -314,12 +313,11 @@ test "default config" {
     try t.expectApproxEqAbs(@as(f64, 0.08), cfg.swipe.distance_pct, 0.0001);
     try t.expectEqual(@as(u16, 0), cfg.gaps.inner);
     try t.expectEqual(@as(u16, 0), cfg.gaps.outer.left);
-    try t.expectEqual(layout_mod.LayoutKind.bsp, cfg.layout);
-    try t.expectEqual(layout_mod.SplitMode.auto, cfg.bsp_split);
-    try t.expectEqual(layout_mod.InsertMode.split, cfg.bsp_insert_mode);
-    try t.expectEqual(layout_mod.InsertionPointPolicy.focused, cfg.bsp_insert_point);
+    try t.expectEqual(tiling.LayoutKind.bsp, cfg.layout);
+    try t.expectEqual(tiling.SplitMode.auto, cfg.bsp_split);
+    try t.expectEqual(tiling.InsertionPointPolicy.focused, cfg.bsp_insert_point);
     try t.expectApproxEqAbs(@as(f64, 0.5), cfg.bsp_split_ratio, 0.0001);
-    try t.expectEqual(layout_mod.InsertChild.second, cfg.new_window_split);
+    try t.expectEqual(tiling.InsertChild.second, cfg.new_window_split);
 }
 
 test "default_keybinds" {
@@ -387,12 +385,11 @@ test "loadFromPath: examples/config.zon" {
 
     try t.expectEqual(@as(usize, 0), cfg.workspace_assignments.len);
     try t.expectEqual(@as(u16, 0), cfg.gaps.inner);
-    try t.expectEqual(layout_mod.LayoutKind.bsp, cfg.layout);
-    try t.expectEqual(layout_mod.SplitMode.auto, cfg.bsp_split);
-    try t.expectEqual(layout_mod.InsertMode.split, cfg.bsp_insert_mode);
-    try t.expectEqual(layout_mod.InsertionPointPolicy.focused, cfg.bsp_insert_point);
+    try t.expectEqual(tiling.LayoutKind.bsp, cfg.layout);
+    try t.expectEqual(tiling.SplitMode.auto, cfg.bsp_split);
+    try t.expectEqual(tiling.InsertionPointPolicy.focused, cfg.bsp_insert_point);
     try t.expectApproxEqAbs(@as(f64, 0.5), cfg.bsp_split_ratio, 0.0001);
-    try t.expectEqual(layout_mod.InsertChild.second, cfg.new_window_split);
+    try t.expectEqual(tiling.InsertChild.second, cfg.new_window_split);
 }
 
 test "loadFromPath: custom zon" {
@@ -413,7 +410,6 @@ test "loadFromPath: custom zon" {
         \\    .gaps = .{ .inner = 8, .outer = .{ .left = 4, .right = 4, .top = 4, .bottom = 4 } },
         \\    .layout = .monocle,
         \\    .bsp_split = .vertical,
-        \\    .bsp_insert_mode = .stack,
         \\    .bsp_insert_point = .last,
         \\    .bsp_split_ratio = 0.6,
         \\    .new_window_split = .first,
@@ -446,10 +442,9 @@ test "loadFromPath: custom zon" {
     try t.expectEqual(@as(u16, 4), cfg.gaps.outer.right);
     try t.expectEqual(@as(u16, 4), cfg.gaps.outer.top);
     try t.expectEqual(@as(u16, 4), cfg.gaps.outer.bottom);
-    try t.expectEqual(layout_mod.LayoutKind.monocle, cfg.layout);
-    try t.expectEqual(layout_mod.SplitMode.vertical, cfg.bsp_split);
-    try t.expectEqual(layout_mod.InsertMode.stack, cfg.bsp_insert_mode);
-    try t.expectEqual(layout_mod.InsertionPointPolicy.last, cfg.bsp_insert_point);
+    try t.expectEqual(tiling.LayoutKind.monocle, cfg.layout);
+    try t.expectEqual(tiling.SplitMode.vertical, cfg.bsp_split);
+    try t.expectEqual(tiling.InsertionPointPolicy.last, cfg.bsp_insert_point);
     try t.expectApproxEqAbs(@as(f64, 0.6), cfg.bsp_split_ratio, 0.0001);
-    try t.expectEqual(layout_mod.InsertChild.first, cfg.new_window_split);
+    try t.expectEqual(tiling.InsertChild.first, cfg.new_window_split);
 }

--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const posix = std.posix;
-const layout_mod = @import("layout.zig");
+const tiling = @import("tiling.zig");
 const osutil = @import("osutil.zig");
 
 const log = std.log.scoped(.ipc);
@@ -20,9 +20,8 @@ pub const IpcCommand = union(enum) {
     move_workspace_to_display: DisplayTarget,
     bsp_ratio_rel: f64,
     bsp_ratio_abs: f64,
-    bsp_insert_mode: layout_mod.InsertMode,
-    bsp_insert_point: layout_mod.InsertionPointPolicy,
-    bsp_mirror: layout_mod.Direction,
+    bsp_insert_point: tiling.InsertionPointPolicy,
+    bsp_mirror: tiling.Direction,
     bsp_equalize,
     bsp_balance,
     bsp_rotate: i32,
@@ -79,12 +78,10 @@ pub const IpcCommand = union(enum) {
             return parseFloat(arg, .bsp_ratio_rel);
         if (stripPrefix(cmd, "bsp ratio abs ")) |arg|
             return parseFloat(arg, .bsp_ratio_abs);
-        if (stripPrefix(cmd, "bsp insert-mode ")) |arg|
-            return parseEnum(layout_mod.InsertMode, arg, .bsp_insert_mode);
         if (stripPrefix(cmd, "bsp insert-point ")) |arg|
-            return parseEnum(layout_mod.InsertionPointPolicy, arg, .bsp_insert_point);
+            return parseEnum(tiling.InsertionPointPolicy, arg, .bsp_insert_point);
         if (stripPrefix(cmd, "bsp mirror ")) |arg|
-            return parseEnum(layout_mod.Direction, arg, .bsp_mirror);
+            return parseEnum(tiling.Direction, arg, .bsp_mirror);
         if (stripPrefix(cmd, "bsp rotate ")) |arg|
             return parseInt(i32, arg, .bsp_rotate);
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,7 +9,8 @@ const skylight = @import("skylight.zig");
 const event_mod = @import("event.zig");
 const window_mod = @import("window.zig");
 const workspace_mod = @import("workspace.zig");
-const layout = @import("layout.zig");
+const tiling = @import("tiling.zig");
+const bsp_mod = tiling.bsp_mod;
 const ipc = @import("ipc.zig");
 const tabgroup = @import("tabgroup.zig");
 const cli = @import("cli.zig");
@@ -770,7 +771,7 @@ fn syncFocusStateForWindowId(focused_wid: u32, source: FocusEventSource) bool {
         ws.focused_wid = leader;
     }
     switchToWindowWorkspaceIfHidden(win);
-    setLayoutLeafActive(win.workspace_id, focused_wid);
+    setTilingActive(win.workspace_id, focused_wid);
 
     return true;
 }
@@ -843,19 +844,17 @@ fn updateStatusBar() void {
     statusbar.setTitleMulti(entries[0..g_display_count]);
 }
 
-fn clearLayoutRoots() void {
+fn clearTilingStates() void {
     for (0..workspace_mod.max_workspaces) |ws_idx| {
-        g_layout_roots[ws_idx] = null;
+        g_tiling_states[ws_idx] = null;
     }
 }
 
-/// Recursively free every workspace's layout tree. Safe to call at any time
-/// after `clearLayoutRoots()` — slots set to null are skipped.
-fn destroyAllLayoutTrees() void {
+fn destroyAllTilingStates() void {
     for (0..workspace_mod.max_workspaces) |ws_idx| {
-        if (g_layout_roots[ws_idx]) |root| {
-            layout.destroyTree(root, g_allocator);
-            g_layout_roots[ws_idx] = null;
+        if (g_tiling_states[ws_idx]) |*st| {
+            st.deinit(g_allocator);
+            g_tiling_states[ws_idx] = null;
         }
     }
 }
@@ -1166,10 +1165,10 @@ var g_sky: ?skylight.SkyLight = null;
 var g_allocator: std.mem.Allocator = undefined;
 var g_store: window_mod.WindowStore = undefined;
 var g_workspaces: workspace_mod.WorkspaceManager = undefined;
-var g_layout_roots: [workspace_mod.max_workspaces]?layout.Node = undefined;
+var g_tiling_states: [workspace_mod.max_workspaces]?tiling.State = undefined;
 var g_displays: [workspace_mod.max_displays]DisplayInfo = undefined;
 var g_display_count: usize = 0;
-var g_bsp_split_mode: layout.SplitMode = .auto;
+var g_bsp_split_mode: tiling.SplitMode = .auto;
 var g_tab_groups: tabgroup.TabGroupManager = undefined;
 var g_pending_role_windows: PendingRoleWindowMap = undefined;
 var g_deferred_window_candidates: DeferredWindowCandidateMap = undefined;
@@ -1198,7 +1197,7 @@ var g_workspace_transition_completion_reason: WorkspaceTransitionCompletionReaso
 var g_pending_focus_entries: [pending_focus_capacity_per_epoch]PendingFocusEntry = undefined;
 var g_pending_focus_count: usize = 0;
 var g_pending_focus_sequence: u64 = 0;
-var g_layout_entries: std.ArrayList(layout.LayoutEntry) = .empty;
+var g_layout_entries: std.ArrayList(tiling.LayoutEntry) = .empty;
 var g_retile_requested_all_displays = false;
 var g_retile_dirty_display_ids: [workspace_mod.max_displays]u32 = [_]u32{0} ** workspace_mod.max_displays;
 var g_retile_dirty_display_count: usize = 0;
@@ -2199,11 +2198,10 @@ pub fn main(init: std.process.Init.Minimal) !void {
         workspace_mod.max_workspaces;
     g_workspaces = workspace_mod.WorkspaceManager.init(g_allocator, ws_count);
     defer g_workspaces.deinit();
-    clearLayoutRoots();
-    // Free per-workspace layout trees on exit. discoverWindows() and later
-    // insertions allocate Split nodes and leaf ArrayLists via g_allocator;
-    // without this, DebugAllocator reports leaks on shutdown error paths.
-    defer destroyAllLayoutTrees();
+    clearTilingStates();
+    // Free per-workspace tiling states on exit. BSP allocates Split nodes and
+    // leaf ArrayLists via g_allocator; without this, DebugAllocator reports leaks.
+    defer destroyAllTilingStates();
     g_tab_groups = tabgroup.TabGroupManager.init(g_allocator);
     defer g_tab_groups.deinit();
     g_pending_role_windows = PendingRoleWindowMap.init(g_allocator);
@@ -2412,36 +2410,40 @@ pub fn bw_retile() void {
     retile();
 }
 
-fn layoutRootPtr(workspace_id: u8) *?layout.Node {
+fn tilingStatePtr(workspace_id: u8) *?tiling.State {
     std.debug.assert(workspace_id > 0 and workspace_id <= workspace_mod.max_workspaces);
-    const ws_idx: usize = workspace_id - 1;
-    return &g_layout_roots[ws_idx];
+    return &g_tiling_states[workspace_id - 1];
 }
 
-fn removeFromLayout(workspace_id: u8, wid: u32) void {
-    const root_ptr = layoutRootPtr(workspace_id);
-    const root = root_ptr.* orelse return;
-    root_ptr.* = layout.removeWindow(root, wid, g_allocator);
+fn removeFromTiling(workspace_id: u8, wid: u32) void {
+    const sp = tilingStatePtr(workspace_id);
+    if (sp.*) |*st| {
+        st.remove(wid, g_allocator);
+        if (st.windowCount() == 0) {
+            st.deinit(g_allocator);
+            sp.* = null;
+        }
+    }
 }
 
-fn insertIntoLayout(workspace_id: u8, wid: u32) void {
-    const root_ptr = layoutRootPtr(workspace_id);
+fn insertIntoTiling(workspace_id: u8, wid: u32) void {
+    const sp = tilingStatePtr(workspace_id);
+    if (sp.* == null) sp.* = tiling.newState(g_config.layout);
     const ws = g_workspaces.get(workspace_id) orelse return;
     const anchor_wid = blk: {
-        const root = root_ptr.* orelse break :blk null;
+        const st = sp.* orelse break :blk null;
         switch (g_config.bsp_insert_point) {
             .focused => {
                 const focused_wid = ws.focused_wid orelse break :blk null;
                 if (focused_wid == wid) break :blk null;
                 break :blk focused_wid;
             },
-            .first => break :blk layout.firstLeafWid(root),
-            .last => break :blk layout.lastLeafWid(root),
+            .first => break :blk st.firstWid(),
+            .last => break :blk st.lastWid(),
             .min_depth => break :blk null,
         }
     };
-    const options: layout.InsertOptions = .{
-        .mode = g_config.bsp_insert_mode,
+    const options: tiling.InsertOptions = .{
         .split_mode = g_bsp_split_mode,
         .child = g_config.new_window_split,
         .anchor_wid = anchor_wid,
@@ -2449,15 +2451,13 @@ fn insertIntoLayout(workspace_id: u8, wid: u32) void {
         .inner_gap = @floatFromInt(g_config.gaps.inner),
         .split_ratio = g_config.bsp_split_ratio,
     };
-    const updated = layout.insertWindow(root_ptr.*, wid, options, g_allocator) catch return;
-    root_ptr.* = updated;
+    sp.*.?.insert(wid, options, g_allocator) catch return;
 }
 
-fn setLayoutLeafActive(workspace_id: u8, wid: u32) void {
-    const root_ptr = layoutRootPtr(workspace_id);
-    if (root_ptr.*) |*root| {
+fn setTilingActive(workspace_id: u8, wid: u32) void {
+    if (tilingStatePtr(workspace_id).*) |*st| {
         const layout_wid = g_tab_groups.resolveLeader(wid);
-        _ = layout.setLeafActive(root, layout_wid);
+        st.setActive(layout_wid);
     }
 }
 
@@ -2472,17 +2472,17 @@ fn replaceManagedWindowId(old_wid: u32, new_wid: u32, frame: window_mod.Window.F
 
     const old = g_store.get(old_wid) orelse return false;
     const ws = g_workspaces.get(old.workspace_id) orelse return false;
-    const root_ptr = layoutRootPtr(old.workspace_id);
+    const sp = tilingStatePtr(old.workspace_id);
     var replaced_in_layout = false;
-    if (root_ptr.*) |*root| {
-        replaced_in_layout = layout.replaceWindowId(root, old_wid, new_wid);
+    if (sp.*) |*st| {
+        replaced_in_layout = st.replaceWid(old_wid, new_wid);
     }
 
     const replaced_in_workspace = ws.replaceWindow(old_wid, new_wid);
     if (!replaced_in_workspace or (old.mode == .tiled and !replaced_in_layout)) {
         if (replaced_in_workspace) _ = ws.replaceWindow(new_wid, old_wid);
         if (replaced_in_layout) {
-            if (root_ptr.*) |*root| _ = layout.replaceWindowId(root, new_wid, old_wid);
+            if (sp.*) |*st| _ = st.replaceWid(new_wid, old_wid);
         }
         log.warn("window id replacement failed old={d} new={d} workspace={d} in_workspace={} in_layout={}", .{
             old_wid,
@@ -2500,7 +2500,7 @@ fn replaceManagedWindowId(old_wid: u32, new_wid: u32, frame: window_mod.Window.F
     g_store.put(updated) catch {
         _ = ws.replaceWindow(new_wid, old_wid);
         if (replaced_in_layout) {
-            if (root_ptr.*) |*root| _ = layout.replaceWindowId(root, new_wid, old_wid);
+            if (sp.*) |*st| _ = st.replaceWid(new_wid, old_wid);
         }
         return false;
     };
@@ -2518,19 +2518,19 @@ fn replaceManagedWindowId(old_wid: u32, new_wid: u32, frame: window_mod.Window.F
 const FocusedLayoutContext = struct {
     focused_wid: u32,
     focused_win: window_mod.Window,
-    root: *layout.Node,
+    state: *tiling.State,
 };
 
 fn focusedLayoutContext() ?FocusedLayoutContext {
     const ws = g_workspaces.active();
     const focused_wid = ws.focused_wid orelse return null;
     const focused_win = g_store.get(focused_wid) orelse return null;
-    const root_ptr = layoutRootPtr(focused_win.workspace_id);
-    if (root_ptr.*) |*root| {
+    const sp = tilingStatePtr(focused_win.workspace_id);
+    if (sp.*) |*st| {
         return .{
             .focused_wid = focused_wid,
             .focused_win = focused_win,
-            .root = root,
+            .state = st,
         };
     }
     return null;
@@ -2563,7 +2563,7 @@ fn frameContainsPoint(frame: window_mod.Window.Frame, point_x: f64, point_y: f64
 }
 
 fn findDropTargetInLayout(
-    node: layout.Node,
+    node: bsp_mod.Node,
     frame: window_mod.Window.Frame,
     inner_gap: f64,
     dragged_wid: u32,
@@ -2575,13 +2575,12 @@ fn findDropTargetInLayout(
     std.debug.assert(inner_gap >= 0);
     switch (node) {
         .leaf => |leaf| {
-            if (leaf.contains(dragged_wid)) return null;
+            if (leaf.wid == dragged_wid) return null;
             if (!frameContainsPoint(frame, center_x, center_y)) return null;
-            const active_wid = leaf.activeWid();
-            const target = g_store.get(active_wid) orelse return null;
+            const target = g_store.get(leaf.wid) orelse return null;
             if (target.mode != .tiled or target.is_fullscreen) return null;
             if (target.workspace_id != workspace_id or target.display_id != display_id) return null;
-            return .{ .wid = active_wid, .frame = frame };
+            return .{ .wid = leaf.wid, .frame = frame };
         },
         .split => |split| {
             const half_gap = inner_gap / 2.0;
@@ -2638,7 +2637,15 @@ fn updateWindowMovePreview(wid: u32) void {
         return;
     }
 
-    const root = layoutRootPtr(win.workspace_id).* orelse {
+    const bsp_state: *bsp_mod.State = blk: {
+        const sp = tilingStatePtr(win.workspace_id);
+        const st: *tiling.State = if (sp.*) |*s| s else { clearDragPreview(); return; };
+        break :blk switch (st.*) {
+            .bsp => |*s| s,
+            else => { clearDragPreview(); return; },
+        };
+    };
+    const bsp_root = bsp_state.root orelse {
         clearDragPreview();
         return;
     };
@@ -2650,7 +2657,7 @@ fn updateWindowMovePreview(wid: u32) void {
     const center_x = win.frame.x + win.frame.width / 2.0;
     const center_y = win.frame.y + win.frame.height / 2.0;
     const target_entry = findDropTargetInLayout(
-        root,
+        bsp_root,
         display_frame,
         @floatFromInt(g_config.gaps.inner),
         wid,
@@ -2700,9 +2707,8 @@ fn commitWindowMovePreview(wid: u32) void {
     if (source.workspace_id != target.workspace_id) return;
     if (source.display_id != target.display_id) return;
 
-    const root_ptr = layoutRootPtr(source.workspace_id);
-    if (root_ptr.*) |*root| {
-        if (layout.swapWindowIds(root, wid, target_wid)) {
+    if (tilingStatePtr(source.workspace_id).*) |*st| {
+        if (st.swapWids(wid, target_wid)) {
             log.info("window move swap wid={d} target={d}", .{ wid, target_wid });
             retile();
         }
@@ -3008,12 +3014,12 @@ fn setWindowMode(wid: u32, target: window_mod.WindowMode) void {
 
     // Leaving tiled → remove from BSP so remaining windows fill the space
     if (old == .tiled) {
-        removeFromLayout(win.workspace_id, wid);
+        removeFromTiling(win.workspace_id, wid);
     }
 
     // Entering tiled → re-insert into BSP
     if (target == .tiled) {
-        insertIntoLayout(win.workspace_id, wid);
+        insertIntoTiling(win.workspace_id, wid);
     }
 
     win.mode = target;
@@ -3594,7 +3600,7 @@ fn discoverWindows() void {
 
         g_store.put(win) catch continue;
         target_ws.addWindow(info.wid) catch continue;
-        insertIntoLayout(target_ws.id, info.wid);
+        insertIntoTiling(target_ws.id, info.wid);
 
         // If assigned to a non-visible workspace, hide immediately
         if (!workspaceVisibleOnDisplay(target_ws.id, managed_display)) {
@@ -3724,7 +3730,7 @@ fn addNewWindowManagedWithAssignment(pid: i32, wid: u32, workspace_id: u8, assig
     g_store.put(win) catch return false;
     ws.addWindow(wid) catch return false;
     if (mode == .tiled) {
-        insertIntoLayout(ws.id, wid);
+        insertIntoTiling(ws.id, wid);
     }
     ws.focused_wid = wid;
 
@@ -4011,14 +4017,14 @@ fn removeWindow(wid: u32) void {
             if (g_workspaces.get(win.workspace_id)) |ws| {
                 ws.removeWindow(wid);
             }
-            removeFromLayout(win.workspace_id, wid);
+            removeFromTiling(win.workspace_id, wid);
         },
         // The group dissolved — restore the solo survivor to workspace and layout.
         .dissolved_solo => |solo_wid| {
             if (g_workspaces.get(win.workspace_id)) |ws| {
                 ws.removeWindow(wid);
             }
-            removeFromLayout(win.workspace_id, wid);
+            removeFromTiling(win.workspace_id, wid);
 
             if (g_workspaces.get(win.workspace_id)) |ws| {
                 var in_ws = false;
@@ -4031,7 +4037,7 @@ fn removeWindow(wid: u32) void {
                 if (!in_ws) {
                     log.info("removeWindow: restoring tab survivor wid={d} to workspace", .{solo_wid});
                     ws.addWindow(solo_wid) catch {};
-                    insertIntoLayout(win.workspace_id, solo_wid);
+                    insertIntoTiling(win.workspace_id, solo_wid);
                 }
             }
         },
@@ -4073,12 +4079,12 @@ fn transferLeaderSlot(workspace_id: u8, old_leader: u32, new_leader: u32) void {
     }
 
     var replaced_in_layout = false;
-    const root_ptr = layoutRootPtr(workspace_id);
-    if (root_ptr.*) |*root| {
-        replaced_in_layout = layout.replaceWindowId(root, old_leader, new_leader);
+    const sp = tilingStatePtr(workspace_id);
+    if (sp.*) |*st| {
+        replaced_in_layout = st.replaceWid(old_leader, new_leader);
     }
     if (!replaced_in_layout) {
-        insertIntoLayout(workspace_id, new_leader);
+        insertIntoTiling(workspace_id, new_leader);
     }
 
     if (replaced_in_workspace and replaced_in_layout) {
@@ -4132,7 +4138,7 @@ fn removeAppWindows(pid: i32) void {
         if (g_workspaces.get(ws_id)) |ws| {
             ws.removeWindow(wid);
         }
-        removeFromLayout(ws_id, wid);
+        removeFromTiling(ws_id, wid);
     }
 }
 
@@ -4298,7 +4304,7 @@ fn adoptOffscreenWindowAsTab(win: window_mod.Window) bool {
     if (g_workspaces.get(win.workspace_id)) |ws| {
         ws.removeWindow(win.wid);
     }
-    removeFromLayout(win.workspace_id, win.wid);
+    removeFromTiling(win.workspace_id, win.wid);
 
     var updated = win;
     updated.frame = frame;
@@ -4347,12 +4353,12 @@ fn updateWindowDisplayAssignment(wid: u32) bool {
         return false;
     }
 
-    removeFromLayout(win.workspace_id, wid);
+    removeFromTiling(win.workspace_id, wid);
     win.frame = frame;
     win.display_id = next_display_id;
     g_store.put(win) catch return false;
     if (win.mode == .tiled) {
-        insertIntoLayout(win.workspace_id, wid);
+        insertIntoTiling(win.workspace_id, wid);
     }
 
     if (!workspaceVisibleOnDisplay(win.workspace_id, win.display_id)) {
@@ -4408,7 +4414,7 @@ fn reconcileDisplayChange() void {
         if (g_workspaces.get(win.workspace_id)) |old_ws| {
             old_ws.removeWindow(win.wid);
         }
-        removeFromLayout(win.workspace_id, win.wid);
+        removeFromTiling(win.workspace_id, win.wid);
 
         const target_display_id = primaryDisplayId();
         const target_workspace_id = activeWorkspaceIdForDisplay(target_display_id);
@@ -4421,14 +4427,14 @@ fn reconcileDisplayChange() void {
             if (target_ws.focused_wid == null) target_ws.focused_wid = win.wid;
         }
         if (win.mode == .tiled) {
-            insertIntoLayout(target_workspace_id, win.wid);
+            insertIntoTiling(target_workspace_id, win.wid);
         }
     }
 }
 
 fn retileDisplay(display_id: u32) void {
     const ws_id = activeWorkspaceIdForDisplay(display_id);
-    const root = layoutRootPtr(ws_id).* orelse return;
+    const st = tilingStatePtr(ws_id).* orelse return;
     const display_slot = displayIndexById(display_id) orelse return;
     const display = g_displays[display_slot].visible;
 
@@ -4440,7 +4446,7 @@ fn retileDisplay(display_id: u32) void {
         .height = display.h - @as(f64, @floatFromInt(@as(u32, outer.top) + @as(u32, outer.bottom))),
     };
 
-    const window_count = layout.windowCount(root);
+    const window_count = st.windowCount();
     std.debug.assert(window_count > 0);
 
     g_layout_entries.clearRetainingCapacity();
@@ -4448,7 +4454,7 @@ fn retileDisplay(display_id: u32) void {
         log.err("retile: layout buffer reserve failed display={d} windows={d}", .{ display_id, window_count });
         return;
     };
-    layout.applyLayout(g_config.layout, root, frame, @floatFromInt(g_config.gaps.inner), &g_layout_entries, g_allocator) catch {
+    st.computeLayout(frame, @floatFromInt(g_config.gaps.inner), &g_layout_entries, g_allocator) catch {
         log.err("retile: layout apply failed display={d} windows={d}", .{ display_id, window_count });
         return;
     };
@@ -4817,7 +4823,7 @@ fn checkTabDragOut(_: i32, wid: u32) void {
     }
     if (!wid_in_ws) {
         ws.addWindow(wid) catch return;
-        insertIntoLayout(win.workspace_id, wid);
+        insertIntoTiling(win.workspace_id, wid);
     }
     ws.focused_wid = wid;
     _ = maybeSetFocusedDisplayForWindow(win, .drag);
@@ -4835,7 +4841,7 @@ fn checkTabDragOut(_: i32, wid: u32) void {
             if (!in_ws) {
                 log.info("drag-out: restoring survivor wid={d} to workspace", .{solo_wid});
                 ws.addWindow(solo_wid) catch {};
-                insertIntoLayout(win.workspace_id, solo_wid);
+                insertIntoTiling(win.workspace_id, solo_wid);
             }
         },
         .none, .leader_changed => {},
@@ -5071,14 +5077,14 @@ fn moveWindowToWorkspace(target_id: u8) void {
 
     // Remove from current workspace BSP + list
     ws.removeWindow(wid);
-    removeFromLayout(ws.id, wid);
+    removeFromTiling(ws.id, wid);
 
     var updated = g_store.get(wid) orelse return;
 
     // Add to target workspace BSP + list
     target_ws.addWindow(wid) catch return;
     if (updated.mode == .tiled) {
-        insertIntoLayout(target_id, wid);
+        insertIntoTiling(target_id, wid);
     }
     if (target_ws.focused_wid == null) {
         target_ws.focused_wid = wid;
@@ -5143,21 +5149,21 @@ fn moveManagedWindowToDisplay(wid: u32, target_display_id: u32) bool {
         };
         updateTabGroupAssignment(wid, target_workspace_id, target_display_id);
 
-        removeFromLayout(source_workspace_id, wid);
+        removeFromTiling(source_workspace_id, wid);
         source_ws.removeWindow(wid);
         target_ws.focused_wid = wid;
         if (updated.mode == .tiled) {
-            insertIntoLayout(target_workspace_id, wid);
+            insertIntoTiling(target_workspace_id, wid);
         }
 
         win = updated;
     } else {
-        removeFromLayout(source_workspace_id, wid);
+        removeFromTiling(source_workspace_id, wid);
         win.display_id = target_display_id;
         g_store.put(win) catch return false;
         updateTabGroupAssignment(wid, source_workspace_id, target_display_id);
         if (win.mode == .tiled) {
-            insertIntoLayout(source_workspace_id, wid);
+            insertIntoTiling(source_workspace_id, wid);
         }
     }
 
@@ -5338,23 +5344,23 @@ fn focusDirection(dir: FocusDir) void {
             _ = shim.bw_ax_focus_window(win.pid, actual_wid);
             ws.focused_wid = wid; // track the leader
             _ = maybeSetFocusedDisplayForWindow(win, .keyboard);
-            setLayoutLeafActive(win.workspace_id, actual_wid);
+            setTilingActive(win.workspace_id, actual_wid);
         }
         return;
     }
 
-    const root_ptr = layoutRootPtr(focused.workspace_id);
-    const root = root_ptr.* orelse return;
+    const sp = tilingStatePtr(focused.workspace_id);
+    const st = sp.* orelse return;
     const stack_forward = switch (dir) {
         .left, .up => false,
         .right, .down => true,
     };
-    if (layout.stackNeighbor(root, focused_wid, stack_forward)) |stack_wid| {
+    if (st.cycleFocus(focused_wid, stack_forward)) |stack_wid| {
         if (g_store.get(stack_wid)) |win| {
             _ = shim.bw_ax_focus_window(win.pid, stack_wid);
             ws.focused_wid = stack_wid;
             _ = maybeSetFocusedDisplayForWindow(win, .keyboard);
-            setLayoutLeafActive(win.workspace_id, stack_wid);
+            setTilingActive(win.workspace_id, stack_wid);
         }
     }
 }
@@ -5439,7 +5445,11 @@ fn ipcDispatch(cmd: []const u8, client_fd: posix.socket_t) void {
                 ipc.writeResponse(client_fd, "err: no focused managed window\n");
                 return;
             };
-            if (!layout.adjustParentRatio(ctx.root, ctx.focused_wid, delta)) {
+            const bsp_state: *bsp_mod.State = switch (ctx.state.*) {
+                .bsp => |*s| s,
+                else => { ipc.writeResponse(client_fd, "err: not in bsp mode\n"); return; },
+            };
+            if (!bsp_state.adjustParentRatio(ctx.focused_wid, delta)) {
                 ipc.writeResponse(client_fd, "err: no parent split\n");
                 return;
             }
@@ -5451,15 +5461,15 @@ fn ipcDispatch(cmd: []const u8, client_fd: posix.socket_t) void {
                 ipc.writeResponse(client_fd, "err: no focused managed window\n");
                 return;
             };
-            if (!layout.setParentRatio(ctx.root, ctx.focused_wid, ratio)) {
+            const bsp_state: *bsp_mod.State = switch (ctx.state.*) {
+                .bsp => |*s| s,
+                else => { ipc.writeResponse(client_fd, "err: not in bsp mode\n"); return; },
+            };
+            if (!bsp_state.setParentRatio(ctx.focused_wid, ratio)) {
                 ipc.writeResponse(client_fd, "err: no parent split\n");
                 return;
             }
             retileDisplay(ctx.focused_win.display_id);
-            ipc.writeResponse(client_fd, "ok\n");
-        },
-        .bsp_insert_mode => |mode| {
-            g_config.bsp_insert_mode = mode;
             ipc.writeResponse(client_fd, "ok\n");
         },
         .bsp_insert_point => |point| {
@@ -5471,42 +5481,39 @@ fn ipcDispatch(cmd: []const u8, client_fd: posix.socket_t) void {
                 ipc.writeResponse(client_fd, "err: no focused managed window\n");
                 return;
             };
-            const root_ptr = layoutRootPtr(ctx.focused_win.workspace_id);
-            if (root_ptr.*) |*root| {
-                layout.mirror(root, axis);
-                retileDisplay(ctx.focused_win.display_id);
-                ipc.writeResponse(client_fd, "ok\n");
-            } else {
-                ipc.writeResponse(client_fd, "err: no layout root\n");
-            }
+            const bsp_state: *bsp_mod.State = switch (ctx.state.*) {
+                .bsp => |*s| s,
+                else => { ipc.writeResponse(client_fd, "err: not in bsp mode\n"); return; },
+            };
+            bsp_state.mirrorTree(axis);
+            retileDisplay(ctx.focused_win.display_id);
+            ipc.writeResponse(client_fd, "ok\n");
         },
         .bsp_equalize => {
             const ctx = focusedLayoutContext() orelse {
                 ipc.writeResponse(client_fd, "err: no focused managed window\n");
                 return;
             };
-            const root_ptr = layoutRootPtr(ctx.focused_win.workspace_id);
-            if (root_ptr.*) |*root| {
-                layout.equalize(root, null, g_config.bsp_split_ratio);
-                retileDisplay(ctx.focused_win.display_id);
-                ipc.writeResponse(client_fd, "ok\n");
-            } else {
-                ipc.writeResponse(client_fd, "err: no layout root\n");
-            }
+            const bsp_state: *bsp_mod.State = switch (ctx.state.*) {
+                .bsp => |*s| s,
+                else => { ipc.writeResponse(client_fd, "err: not in bsp mode\n"); return; },
+            };
+            bsp_state.equalizeTree(null, g_config.bsp_split_ratio);
+            retileDisplay(ctx.focused_win.display_id);
+            ipc.writeResponse(client_fd, "ok\n");
         },
         .bsp_balance => {
             const ctx = focusedLayoutContext() orelse {
                 ipc.writeResponse(client_fd, "err: no focused managed window\n");
                 return;
             };
-            const root_ptr = layoutRootPtr(ctx.focused_win.workspace_id);
-            if (root_ptr.*) |*root| {
-                _ = layout.balance(root, null);
-                retileDisplay(ctx.focused_win.display_id);
-                ipc.writeResponse(client_fd, "ok\n");
-            } else {
-                ipc.writeResponse(client_fd, "err: no layout root\n");
-            }
+            const bsp_state: *bsp_mod.State = switch (ctx.state.*) {
+                .bsp => |*s| s,
+                else => { ipc.writeResponse(client_fd, "err: not in bsp mode\n"); return; },
+            };
+            bsp_state.balanceTree(null);
+            retileDisplay(ctx.focused_win.display_id);
+            ipc.writeResponse(client_fd, "ok\n");
         },
         .bsp_rotate => |degrees| {
             if (!(degrees == 90 or degrees == 180 or degrees == 270)) {
@@ -5517,14 +5524,13 @@ fn ipcDispatch(cmd: []const u8, client_fd: posix.socket_t) void {
                 ipc.writeResponse(client_fd, "err: no focused managed window\n");
                 return;
             };
-            const root_ptr = layoutRootPtr(ctx.focused_win.workspace_id);
-            if (root_ptr.*) |*root| {
-                layout.rotate(root, degrees);
-                retileDisplay(ctx.focused_win.display_id);
-                ipc.writeResponse(client_fd, "ok\n");
-            } else {
-                ipc.writeResponse(client_fd, "err: no layout root\n");
-            }
+            const bsp_state: *bsp_mod.State = switch (ctx.state.*) {
+                .bsp => |*s| s,
+                else => { ipc.writeResponse(client_fd, "err: not in bsp mode\n"); return; },
+            };
+            bsp_state.rotateTree(degrees);
+            retileDisplay(ctx.focused_win.display_id);
+            ipc.writeResponse(client_fd, "ok\n");
         },
         .query_windows => |format| ipcQueryWindows(client_fd, format),
         .query_workspaces => |format| ipcQueryWorkspaces(client_fd, format),

--- a/src/tiling.zig
+++ b/src/tiling.zig
@@ -60,7 +60,7 @@ pub const State = union(LayoutKind) {
     pub fn insert(self: *State, wid: WindowId, opts: InsertOptions, allocator: std.mem.Allocator) !void {
         switch (self.*) {
             .bsp => |*s| try s.insert(wid, opts, allocator),
-            .monocle => |*s| try s.insert(wid, allocator),
+            .monocle => |*s| try s.insert(wid, opts, allocator),
         }
     }
 

--- a/src/tiling.zig
+++ b/src/tiling.zig
@@ -1,0 +1,142 @@
+const std = @import("std");
+const WindowId = @import("window.zig").WindowId;
+const Frame = @import("window.zig").Window.Frame;
+
+pub const bsp_mod = @import("tiling/bsp.zig");
+pub const monocle_mod = @import("tiling/monocle.zig");
+
+// ── Comptime interface validator ──────────────────────────────────────────────
+//
+// Adding a new tiling algorithm requires implementing these declarations.
+// The comptime block below catches missing exports at compile time.
+
+fn requireAlgoInterface(comptime M: type) void {
+    if (!@hasDecl(M, "State"))
+        @compileError("tiling algo " ++ @typeName(M) ++ " missing: State");
+    const required_methods = [_][]const u8{
+        "insert", "remove", "windowCount", "firstWid", "lastWid",
+        "cycleFocus", "setActive", "replaceWid", "swapWids", "computeLayout",
+    };
+    for (required_methods) |name| {
+        if (!@hasDecl(M.State, name))
+            @compileError("tiling algo " ++ @typeName(M) ++ " State missing method: " ++ name);
+    }
+}
+
+comptime {
+    requireAlgoInterface(bsp_mod);
+    requireAlgoInterface(monocle_mod);
+}
+
+// ── Re-exports ────────────────────────────────────────────────────────────────
+
+pub const LayoutEntry = bsp_mod.LayoutEntry;
+pub const InsertOptions = bsp_mod.InsertOptions;
+pub const InsertionPointPolicy = bsp_mod.InsertionPointPolicy;
+pub const SplitMode = bsp_mod.SplitMode;
+pub const InsertChild = bsp_mod.InsertChild;
+pub const Direction = bsp_mod.Direction;
+
+// ── Layout algorithm selection ────────────────────────────────────────────────
+
+pub const LayoutKind = enum {
+    bsp,
+    monocle,
+};
+
+// ── Dispatch state ────────────────────────────────────────────────────────────
+
+pub const State = union(LayoutKind) {
+    bsp: bsp_mod.State,
+    monocle: monocle_mod.State,
+
+    pub fn deinit(self: *State, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .bsp => |*s| s.deinit(allocator),
+            .monocle => |*s| s.deinit(allocator),
+        }
+    }
+
+    pub fn insert(self: *State, wid: WindowId, opts: InsertOptions, allocator: std.mem.Allocator) !void {
+        switch (self.*) {
+            .bsp => |*s| try s.insert(wid, opts, allocator),
+            .monocle => |*s| try s.insert(wid, allocator),
+        }
+    }
+
+    pub fn remove(self: *State, wid: WindowId, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .bsp => |*s| s.remove(wid, allocator),
+            .monocle => |*s| s.remove(wid, allocator),
+        }
+    }
+
+    pub fn windowCount(self: *const State) usize {
+        return switch (self.*) {
+            .bsp => |*s| s.windowCount(),
+            .monocle => |*s| s.windowCount(),
+        };
+    }
+
+    pub fn firstWid(self: *const State) ?WindowId {
+        return switch (self.*) {
+            .bsp => |*s| s.firstWid(),
+            .monocle => |*s| s.firstWid(),
+        };
+    }
+
+    pub fn lastWid(self: *const State) ?WindowId {
+        return switch (self.*) {
+            .bsp => |*s| s.lastWid(),
+            .monocle => |*s| s.lastWid(),
+        };
+    }
+
+    pub fn cycleFocus(self: *const State, wid: WindowId, forward: bool) ?WindowId {
+        return switch (self.*) {
+            .bsp => |*s| s.cycleFocus(wid, forward),
+            .monocle => |*s| s.cycleFocus(wid, forward),
+        };
+    }
+
+    pub fn setActive(self: *State, wid: WindowId) void {
+        switch (self.*) {
+            .bsp => |*s| s.setActive(wid),
+            .monocle => |*s| s.setActive(wid),
+        }
+    }
+
+    pub fn replaceWid(self: *State, old: WindowId, new: WindowId) bool {
+        return switch (self.*) {
+            .bsp => |*s| s.replaceWid(old, new),
+            .monocle => |*s| s.replaceWid(old, new),
+        };
+    }
+
+    pub fn swapWids(self: *State, a: WindowId, b: WindowId) bool {
+        return switch (self.*) {
+            .bsp => |*s| s.swapWids(a, b),
+            .monocle => |*s| s.swapWids(a, b),
+        };
+    }
+
+    pub fn computeLayout(
+        self: *const State,
+        frame: Frame,
+        inner_gap: f64,
+        out: *std.ArrayList(LayoutEntry),
+        allocator: std.mem.Allocator,
+    ) !void {
+        switch (self.*) {
+            .bsp => |*s| try s.computeLayout(frame, inner_gap, out, allocator),
+            .monocle => |*s| try s.computeLayout(frame, inner_gap, out, allocator),
+        }
+    }
+};
+
+pub fn newState(kind: LayoutKind) State {
+    return switch (kind) {
+        .bsp => .{ .bsp = bsp_mod.State.init() },
+        .monocle => .{ .monocle = monocle_mod.State.init() },
+    };
+}

--- a/src/tiling/bsp.zig
+++ b/src/tiling/bsp.zig
@@ -84,7 +84,7 @@ pub const State = struct {
 
     pub fn remove(s: *State, wid: WindowId, allocator: std.mem.Allocator) void {
         const root = s.root orelse return;
-        s.root = removeWindow(root, wid, allocator);
+        s.root = removeFrom(root, wid, allocator);
     }
 
     pub fn windowCount(s: *const State) usize {
@@ -425,10 +425,6 @@ fn windowCountTree(node: Node) usize {
         .leaf => 1,
         .split => |split| windowCountTree(split.left) + windowCountTree(split.right),
     };
-}
-
-fn removeWindow(root: Node, wid: WindowId, allocator: std.mem.Allocator) ?Node {
-    return removeFrom(root, wid, allocator);
 }
 
 fn swapWindowIds(root: *Node, first_wid: WindowId, second_wid: WindowId) bool {

--- a/src/tiling/bsp.zig
+++ b/src/tiling/bsp.zig
@@ -1,15 +1,12 @@
 const std = @import("std");
-const WindowId = @import("window.zig").WindowId;
-const Frame = @import("window.zig").Window.Frame;
+const WindowId = @import("../window.zig").WindowId;
+const Frame = @import("../window.zig").Window.Frame;
+
+// ── Shared types ─────────────────────────────────────────────────────────────
 
 pub const Direction = enum {
     horizontal,
     vertical,
-};
-
-pub const LayoutKind = enum {
-    bsp,
-    monocle,
 };
 
 pub const SplitMode = enum {
@@ -23,11 +20,6 @@ pub const InsertChild = enum {
     second,
 };
 
-pub const InsertMode = enum {
-    split,
-    stack,
-};
-
 pub const InsertionPointPolicy = enum {
     focused,
     first,
@@ -36,7 +28,6 @@ pub const InsertionPointPolicy = enum {
 };
 
 pub const InsertOptions = struct {
-    mode: InsertMode = .split,
     split_mode: SplitMode,
     child: InsertChild,
     anchor_wid: ?WindowId = null,
@@ -44,6 +35,13 @@ pub const InsertOptions = struct {
     inner_gap: f64 = 0,
     split_ratio: f64 = 0.5,
 };
+
+pub const LayoutEntry = struct {
+    wid: WindowId,
+    frame: Frame,
+};
+
+// ── BSP tree types ────────────────────────────────────────────────────────────
 
 const min_split_ratio: f64 = 0.1;
 const max_split_ratio: f64 = 0.9;
@@ -53,72 +51,7 @@ pub const Node = union(enum) {
     split: *Split,
 
     pub const Leaf = struct {
-        windows: std.ArrayListUnmanaged(WindowId) = .empty,
-
-        pub fn initSingle(allocator: std.mem.Allocator, wid: WindowId) !Leaf {
-            var leaf: Leaf = .{};
-            try leaf.windows.append(allocator, wid);
-            return leaf;
-        }
-
-        pub fn deinit(self: *Leaf, allocator: std.mem.Allocator) void {
-            self.windows.deinit(allocator);
-            self.* = .{};
-        }
-
-        pub fn activeWid(self: *const Leaf) WindowId {
-            std.debug.assert(self.windows.items.len > 0);
-            return self.windows.items[0];
-        }
-
-        pub fn contains(self: *const Leaf, wid: WindowId) bool {
-            for (self.windows.items) |existing| {
-                if (existing == wid) return true;
-            }
-            return false;
-        }
-
-        pub fn appendOnTop(self: *Leaf, allocator: std.mem.Allocator, wid: WindowId) !void {
-            if (self.contains(wid)) return;
-            try self.windows.ensureUnusedCapacity(allocator, 1);
-            const len = self.windows.items.len;
-            self.windows.items.len = len + 1;
-            var index = len;
-            while (index > 0) : (index -= 1) {
-                self.windows.items[index] = self.windows.items[index - 1];
-            }
-            self.windows.items[0] = wid;
-        }
-
-        pub fn removeWid(self: *Leaf, wid: WindowId) bool {
-            for (self.windows.items, 0..) |existing, index| {
-                if (existing == wid) {
-                    _ = self.windows.orderedRemove(index);
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        pub fn promoteWid(self: *Leaf, wid: WindowId) bool {
-            for (self.windows.items, 0..) |existing, index| {
-                if (existing != wid) continue;
-                if (index == 0) return true;
-
-                const target = self.windows.items[index];
-                var shift = index;
-                while (shift > 0) : (shift -= 1) {
-                    self.windows.items[shift] = self.windows.items[shift - 1];
-                }
-                self.windows.items[0] = target;
-                return true;
-            }
-            return false;
-        }
-
-        pub fn count(self: *const Leaf) usize {
-            return self.windows.items.len;
-        }
+        wid: WindowId,
     };
 };
 
@@ -129,20 +62,98 @@ pub const Split = struct {
     right: Node,
 };
 
-pub const LayoutEntry = struct {
-    wid: WindowId,
-    frame: Frame,
+// ── State ─────────────────────────────────────────────────────────────────────
+
+pub const State = struct {
+    root: ?Node = null,
+
+    pub fn init() State {
+        return .{};
+    }
+
+    pub fn deinit(s: *State, allocator: std.mem.Allocator) void {
+        if (s.root) |root| destroyTree(root, allocator);
+        s.root = null;
+    }
+
+    // ── Common interface ──────────────────────────────────────────────────────
+
+    pub fn insert(s: *State, wid: WindowId, opts: InsertOptions, allocator: std.mem.Allocator) !void {
+        s.root = try insertWindow(s.root, wid, opts, allocator);
+    }
+
+    pub fn remove(s: *State, wid: WindowId, allocator: std.mem.Allocator) void {
+        const root = s.root orelse return;
+        s.root = removeWindow(root, wid, allocator);
+    }
+
+    pub fn windowCount(s: *const State) usize {
+        return if (s.root) |root| windowCountTree(root) else 0;
+    }
+
+    pub fn firstWid(s: *const State) ?WindowId {
+        return if (s.root) |root| firstLeafWid(root) else null;
+    }
+
+    pub fn lastWid(s: *const State) ?WindowId {
+        return if (s.root) |root| lastLeafWid(root) else null;
+    }
+
+    pub fn cycleFocus(_: *const State, _: WindowId, _: bool) ?WindowId {
+        return null;
+    }
+
+    pub fn setActive(_: *State, _: WindowId) void {}
+
+    pub fn replaceWid(s: *State, old: WindowId, new: WindowId) bool {
+        return if (s.root) |*root| replaceWindowId(root, old, new) else false;
+    }
+
+    pub fn swapWids(s: *State, a: WindowId, b: WindowId) bool {
+        return if (s.root) |*root| swapWindowIds(root, a, b) else false;
+    }
+
+    pub fn computeLayout(
+        s: *const State,
+        frame: Frame,
+        inner_gap: f64,
+        out: *std.ArrayList(LayoutEntry),
+        allocator: std.mem.Allocator,
+    ) !void {
+        const root = s.root orelse return;
+        try applyBsp(root, frame, inner_gap, out, allocator);
+    }
+
+    // ── BSP-only operations ───────────────────────────────────────────────────
+
+    pub fn adjustParentRatio(s: *State, wid: WindowId, delta: f64) bool {
+        return if (s.root) |*root| adjustParentRatioFn(root, wid, delta) else false;
+    }
+
+    pub fn setParentRatio(s: *State, wid: WindowId, ratio: f64) bool {
+        return if (s.root) |*root| setParentRatioFn(root, wid, ratio) else false;
+    }
+
+    pub fn mirrorTree(s: *State, axis: Direction) void {
+        if (s.root) |*root| mirror(root, axis);
+    }
+
+    pub fn equalizeTree(s: *State, axis: ?Direction, ratio: f64) void {
+        if (s.root) |*root| equalize(root, axis, ratio);
+    }
+
+    pub fn balanceTree(s: *State, axis: ?Direction) void {
+        if (s.root) |*root| _ = balance(root, axis);
+    }
+
+    pub fn rotateTree(s: *State, degrees: i32) void {
+        if (s.root) |*root| rotate(root, degrees);
+    }
 };
 
-/// Insert a window into the BSP tree by splitting a selected leaf. If
-/// `anchor_wid` is present, that matching leaf is split. Otherwise the
-/// shallowest leaf is split (yabai-style minimum-depth insertion).
-///
-/// `InsertChild.second` keeps existing content as first child and places the
-/// new window in second child (right/bottom). `InsertChild.first` does the
-/// inverse (left/top).
-/// If root is null, returns a new leaf node.
-pub fn insertWindow(root: ?Node, wid: WindowId, options: InsertOptions, allocator: std.mem.Allocator) !Node {
+// ── Tree insertion ────────────────────────────────────────────────────────────
+
+fn insertWindow(root: ?Node, wid: WindowId, options: InsertOptions, allocator: std.mem.Allocator) !Node {
     if (root) |r| {
         var updated = r;
         var target_leaf: ?*Node = null;
@@ -155,28 +166,19 @@ pub fn insertWindow(root: ?Node, wid: WindowId, options: InsertOptions, allocato
             findShallowestLeaf(&updated, 0, &target_leaf, &shallowest_depth);
         }
         std.debug.assert(target_leaf != null);
-        if (options.mode == .stack) {
-            switch (target_leaf.?.*) {
-                .leaf => |*leaf| {
-                    try leaf.appendOnTop(allocator, wid);
-                    return updated;
-                },
-                .split => unreachable,
-            }
-        }
 
         const split_direction = resolveSplitDirection(updated, target_leaf.?, options);
         const split_ratio = clampedSplitRatio(options.split_ratio);
         try splitLeafNode(target_leaf.?, wid, split_direction, options.child, split_ratio, allocator);
         return updated;
     }
-    return .{ .leaf = try Node.Leaf.initSingle(allocator, wid) };
+    return .{ .leaf = .{ .wid = wid } };
 }
 
 fn findLeafNode(node: *Node, target_wid: WindowId) ?*Node {
     switch (node.*) {
         .leaf => |leaf| {
-            if (leaf.contains(target_wid)) return node;
+            if (leaf.wid == target_wid) return node;
             return null;
         },
         .split => |split| {
@@ -188,7 +190,7 @@ fn findLeafNode(node: *Node, target_wid: WindowId) ?*Node {
 
 fn resolveSplitDirection(root: Node, target_leaf: *Node, options: InsertOptions) Direction {
     const target_wid = switch (target_leaf.*) {
-        .leaf => |leaf| leaf.activeWid(),
+        .leaf => |leaf| leaf.wid,
         .split => unreachable,
     };
     switch (options.split_mode) {
@@ -205,7 +207,7 @@ fn resolveSplitDirection(root: Node, target_leaf: *Node, options: InsertOptions)
 
 fn findLeafFrameByWindowId(node: Node, frame: Frame, inner_gap: f64, target_wid: WindowId) ?Frame {
     return switch (node) {
-        .leaf => |leaf| if (leaf.contains(target_wid)) frame else null,
+        .leaf => |leaf| if (leaf.wid == target_wid) frame else null,
         .split => |split| {
             const half_gap = inner_gap / 2.0;
             var left_frame = frame;
@@ -255,12 +257,12 @@ fn splitLeafNode(node: *Node, wid: WindowId, split_direction: Direction, child: 
             var right_child: Node = undefined;
             switch (child) {
                 .first => {
-                    left_child = .{ .leaf = try Node.Leaf.initSingle(allocator, wid) };
+                    left_child = .{ .leaf = .{ .wid = wid } };
                     right_child = .{ .leaf = leaf };
                 },
                 .second => {
                     left_child = .{ .leaf = leaf };
-                    right_child = .{ .leaf = try Node.Leaf.initSingle(allocator, wid) };
+                    right_child = .{ .leaf = .{ .wid = wid } };
                 },
             }
             const split = try allocator.create(Split);
@@ -280,62 +282,35 @@ fn clampedSplitRatio(value: f64) f64 {
     return std.math.clamp(value, min_split_ratio, max_split_ratio);
 }
 
-pub fn firstLeafWid(root: Node) WindowId {
+// ── Tree queries ──────────────────────────────────────────────────────────────
+
+fn firstLeafWid(root: Node) WindowId {
     return switch (root) {
-        .leaf => |leaf| leaf.activeWid(),
+        .leaf => |leaf| leaf.wid,
         .split => |split| firstLeafWid(split.left),
     };
 }
 
-pub fn lastLeafWid(root: Node) WindowId {
+fn lastLeafWid(root: Node) WindowId {
     return switch (root) {
-        .leaf => |leaf| leaf.activeWid(),
+        .leaf => |leaf| leaf.wid,
         .split => |split| lastLeafWid(split.right),
     };
 }
 
-pub fn setLeafActive(root: *Node, wid: WindowId) bool {
-    switch (root.*) {
-        .leaf => |*leaf| return leaf.promoteWid(wid),
-        .split => |split| {
-            if (setLeafActive(&split.left, wid)) return true;
-            return setLeafActive(&split.right, wid);
-        },
-    }
-}
-
-pub fn stackNeighbor(root: Node, wid: WindowId, forward: bool) ?WindowId {
-    return switch (root) {
-        .leaf => |leaf| {
-            if (!leaf.contains(wid)) return null;
-            const count = leaf.count();
-            if (count <= 1) return null;
-            for (leaf.windows.items, 0..) |existing, index| {
-                if (existing != wid) continue;
-                const next_index = if (forward)
-                    (index + 1) % count
-                else if (index == 0) count - 1 else index - 1;
-                return leaf.windows.items[next_index];
-            }
-            return null;
-        },
-        .split => |split| stackNeighbor(split.left, wid, forward) orelse stackNeighbor(split.right, wid, forward),
-    };
-}
-
-pub fn adjustParentRatio(root: *Node, wid: WindowId, delta: f64) bool {
+fn adjustParentRatioFn(root: *Node, wid: WindowId, delta: f64) bool {
     const split = findParentSplit(root, wid) orelse return false;
     split.ratio = clampedSplitRatio(split.ratio + delta);
     return true;
 }
 
-pub fn setParentRatio(root: *Node, wid: WindowId, ratio: f64) bool {
+fn setParentRatioFn(root: *Node, wid: WindowId, ratio: f64) bool {
     const split = findParentSplit(root, wid) orelse return false;
     split.ratio = clampedSplitRatio(ratio);
     return true;
 }
 
-pub fn mirror(root: *Node, axis: Direction) void {
+fn mirror(root: *Node, axis: Direction) void {
     switch (root.*) {
         .leaf => {},
         .split => |split| {
@@ -350,7 +325,7 @@ pub fn mirror(root: *Node, axis: Direction) void {
     }
 }
 
-pub fn equalize(root: *Node, axis: ?Direction, ratio: f64) void {
+fn equalize(root: *Node, axis: ?Direction, ratio: f64) void {
     const clamped = clampedSplitRatio(ratio);
     switch (root.*) {
         .leaf => {},
@@ -364,14 +339,14 @@ pub fn equalize(root: *Node, axis: ?Direction, ratio: f64) void {
     }
 }
 
-pub fn balance(root: *Node, axis: ?Direction) usize {
+fn balance(root: *Node, axis: ?Direction) usize {
     switch (root.*) {
-        .leaf => |leaf| return leaf.count(),
+        .leaf => return 1,
         .split => |split| {
             const left_count = balance(&split.left, axis);
             const right_count = balance(&split.right, axis);
             const total = left_count + right_count;
-            if (total > 0 and (axis == null or split.direction == axis.?)) {
+            if (axis == null or split.direction == axis.?) {
                 split.ratio = clampedSplitRatio(@as(f64, @floatFromInt(left_count)) / @as(f64, @floatFromInt(total)));
             }
             return total;
@@ -379,7 +354,7 @@ pub fn balance(root: *Node, axis: ?Direction) usize {
     }
 }
 
-pub fn rotate(root: *Node, degrees: i32) void {
+fn rotate(root: *Node, degrees: i32) void {
     switch (root.*) {
         .leaf => {},
         .split => |split| {
@@ -387,8 +362,6 @@ pub fn rotate(root: *Node, degrees: i32) void {
             rotate(&split.right, degrees);
             switch (degrees) {
                 90 => {
-                    // Swap children + invert ratio only for vertical splits.
-                    // Horizontal splits just need the axis flip.
                     if (split.direction == .vertical) {
                         const tmp = split.left;
                         split.left = split.right;
@@ -404,8 +377,6 @@ pub fn rotate(root: *Node, degrees: i32) void {
                     split.ratio = 1.0 - split.ratio;
                 },
                 270 => {
-                    // Swap children + invert ratio only for horizontal splits.
-                    // Vertical splits just need the axis flip.
                     if (split.direction == .horizontal) {
                         const tmp = split.left;
                         split.left = split.right;
@@ -444,78 +415,46 @@ fn findParentSplit(node: *Node, wid: WindowId) ?*Split {
 
 fn nodeContainsWid(node: Node, wid: WindowId) bool {
     return switch (node) {
-        .leaf => |leaf| leaf.contains(wid),
+        .leaf => |leaf| leaf.wid == wid,
         .split => |split| nodeContainsWid(split.left, wid) or nodeContainsWid(split.right, wid),
     };
 }
 
-pub fn windowCount(node: Node) usize {
+fn windowCountTree(node: Node) usize {
     return switch (node) {
-        .leaf => |leaf| leaf.count(),
-        .split => |split| windowCount(split.left) + windowCount(split.right),
+        .leaf => 1,
+        .split => |split| windowCountTree(split.left) + windowCountTree(split.right),
     };
 }
 
-/// Remove a window from the BSP tree. Returns the collapsed tree, or null if the
-/// tree becomes empty.
-pub fn removeWindow(root: Node, wid: WindowId, allocator: std.mem.Allocator) ?Node {
+fn removeWindow(root: Node, wid: WindowId, allocator: std.mem.Allocator) ?Node {
     return removeFrom(root, wid, allocator);
 }
 
-/// Swap two window IDs in-place inside an existing BSP tree.
-///
-/// Returns true when both windows were present and swapped.
-pub fn swapWindowIds(root: *Node, first_wid: WindowId, second_wid: WindowId) bool {
+fn swapWindowIds(root: *Node, first_wid: WindowId, second_wid: WindowId) bool {
     if (first_wid == second_wid) return false;
-    var first_slot: ?LeafSlot = null;
-    var second_slot: ?LeafSlot = null;
-    findLeafSlot(root, first_wid, &first_slot);
-    findLeafSlot(root, second_wid, &second_slot);
-    if (first_slot == null or second_slot == null) return false;
-
-    const first = first_slot.?;
-    const second = second_slot.?;
-    const first_id = first.leaf.windows.items[first.index];
-    first.leaf.windows.items[first.index] = second.leaf.windows.items[second.index];
-    second.leaf.windows.items[second.index] = first_id;
+    const a = findLeafPtr(root, first_wid) orelse return false;
+    const b = findLeafPtr(root, second_wid) orelse return false;
+    const tmp = a.wid;
+    a.wid = b.wid;
+    b.wid = tmp;
     return true;
 }
 
-/// Replace a window ID in-place inside an existing BSP tree, preserving the
-/// leaf position. Used for tab-group leader succession: the new leader must
-/// inherit the old leader's layout slot instead of being re-inserted.
-///
-/// Returns true when old_wid was present and replaced.
-pub fn replaceWindowId(root: *Node, old_wid: WindowId, new_wid: WindowId) bool {
+fn replaceWindowId(root: *Node, old_wid: WindowId, new_wid: WindowId) bool {
     std.debug.assert(old_wid != 0 and new_wid != 0);
     if (old_wid == new_wid) return false;
-
-    var slot: ?LeafSlot = null;
-    findLeafSlot(root, old_wid, &slot);
-    const found = slot orelse return false;
-    found.leaf.windows.items[found.index] = new_wid;
+    const leaf = findLeafPtr(root, old_wid) orelse return false;
+    leaf.wid = new_wid;
     return true;
 }
 
-const LeafSlot = struct {
-    leaf: *Node.Leaf,
-    index: usize,
-};
-
-fn findLeafSlot(node: *Node, wid: WindowId, out: *?LeafSlot) void {
-    if (out.* != null) return;
+fn findLeafPtr(node: *Node, wid: WindowId) ?*Node.Leaf {
     switch (node.*) {
-        .leaf => |*leaf| {
-            for (leaf.windows.items, 0..) |existing, index| {
-                if (existing == wid) {
-                    out.* = .{ .leaf = leaf, .index = index };
-                    return;
-                }
-            }
-        },
+        .leaf => |*leaf| return if (leaf.wid == wid) leaf else null,
         .split => |split| {
-            findLeafSlot(&split.left, wid, out);
-            findLeafSlot(&split.right, wid, out);
+            if (findLeafPtr(&split.left, wid)) |l| return l;
+            return findLeafPtr(&split.right, wid);
         },
     }
 }
@@ -523,13 +462,8 @@ fn findLeafSlot(node: *Node, wid: WindowId, out: *?LeafSlot) void {
 fn removeFrom(node: Node, wid: WindowId, allocator: std.mem.Allocator) ?Node {
     switch (node) {
         .leaf => |leaf| {
-            var updated_leaf = leaf;
-            if (!updated_leaf.removeWid(wid)) return node;
-            if (updated_leaf.count() == 0) {
-                updated_leaf.deinit(allocator);
-                return null;
-            }
-            return .{ .leaf = updated_leaf };
+            if (leaf.wid != wid) return node;
+            return null;
         },
         .split => |split| {
             const left_result = removeFrom(split.left, wid, allocator);
@@ -559,24 +493,10 @@ fn removeFrom(node: Node, wid: WindowId, allocator: std.mem.Allocator) ?Node {
     }
 }
 
-/// Walk the BSP tree and compute a frame for each leaf window within the given
-/// bounding frame. `inner_gap` is the pixel spacing inserted between adjacent windows.
-pub fn applyLayout(kind: LayoutKind, node: Node, frame: Frame, inner_gap: f64, output: *std.ArrayList(LayoutEntry), allocator: std.mem.Allocator) !void {
-    std.debug.assert(inner_gap >= 0);
-    switch (kind) {
-        .bsp => try applyBsp(node, frame, inner_gap, output, allocator),
-        .monocle => try applyMonocle(node, frame, output, allocator),
-    }
-}
-
 fn applyBsp(node: Node, frame: Frame, inner_gap: f64, output: *std.ArrayList(LayoutEntry), allocator: std.mem.Allocator) !void {
     switch (node) {
         .leaf => |leaf| {
-            var idx = leaf.windows.items.len;
-            while (idx > 0) : (idx -= 1) {
-                const wid = leaf.windows.items[idx - 1];
-                try output.append(allocator, .{ .wid = wid, .frame = frame });
-            }
+            try output.append(allocator, .{ .wid = leaf.wid, .frame = frame });
         },
         .split => |split| {
             const half_gap = inner_gap / 2.0;
@@ -604,29 +524,9 @@ fn applyBsp(node: Node, frame: Frame, inner_gap: f64, output: *std.ArrayList(Lay
     }
 }
 
-fn applyMonocle(node: Node, frame: Frame, output: *std.ArrayList(LayoutEntry), allocator: std.mem.Allocator) !void {
+fn destroyTree(node: Node, allocator: std.mem.Allocator) void {
     switch (node) {
-        .leaf => |leaf| {
-            var idx = leaf.windows.items.len;
-            while (idx > 0) : (idx -= 1) {
-                const wid = leaf.windows.items[idx - 1];
-                try output.append(allocator, .{ .wid = wid, .frame = frame });
-            }
-        },
-        .split => |split| {
-            try applyMonocle(split.left, frame, output, allocator);
-            try applyMonocle(split.right, frame, output, allocator);
-        },
-    }
-}
-
-/// Recursively free all Split nodes in the tree.
-pub fn destroyTree(node: Node, allocator: std.mem.Allocator) void {
-    switch (node) {
-        .leaf => |leaf| {
-            var mutable_leaf = leaf;
-            mutable_leaf.deinit(allocator);
-        },
+        .leaf => {},
         .split => |split| {
             destroyTree(split.left, allocator);
             destroyTree(split.right, allocator);
@@ -635,20 +535,20 @@ pub fn destroyTree(node: Node, allocator: std.mem.Allocator) void {
     }
 }
 
-// Tests
+// ── Tests ─────────────────────────────────────────────────────────────────────
 
-test "replaceWindowId swaps a wid in place and preserves the leaf slot" {
+test "replaceWid swaps a wid in place and preserves the leaf slot" {
     const allocator = std.testing.allocator;
     const options: InsertOptions = .{ .split_mode = .auto, .child = .second };
 
-    var root: Node = try insertWindow(null, 1, options, allocator);
-    root = try insertWindow(root, 2, options, allocator);
-    defer destroyTree(root, allocator);
+    var s = State.init();
+    try s.insert(1, options, allocator);
+    try s.insert(2, options, allocator);
+    defer s.deinit(allocator);
 
-    try std.testing.expect(replaceWindowId(&root, 1, 9));
-    try std.testing.expectEqual(@as(WindowId, 9), firstLeafWid(root));
-    try std.testing.expectEqual(@as(WindowId, 2), lastLeafWid(root));
+    try std.testing.expect(s.replaceWid(1, 9));
+    try std.testing.expectEqual(@as(WindowId, 9), s.firstWid().?);
+    try std.testing.expectEqual(@as(WindowId, 2), s.lastWid().?);
 
-    // The old wid is gone; replacing it again must fail.
-    try std.testing.expect(!replaceWindowId(&root, 1, 10));
+    try std.testing.expect(!s.replaceWid(1, 10));
 }

--- a/src/tiling/monocle.zig
+++ b/src/tiling/monocle.zig
@@ -1,0 +1,109 @@
+const std = @import("std");
+const WindowId = @import("../window.zig").WindowId;
+const Frame = @import("../window.zig").Window.Frame;
+const LayoutEntry = @import("bsp.zig").LayoutEntry;
+
+pub const State = struct {
+    windows: std.ArrayListUnmanaged(WindowId) = .empty,
+
+    pub fn init() State {
+        return .{};
+    }
+
+    pub fn deinit(s: *State, allocator: std.mem.Allocator) void {
+        s.windows.deinit(allocator);
+    }
+
+    // ── Common interface ──────────────────────────────────────────────────────
+
+    pub fn insert(s: *State, wid: WindowId, allocator: std.mem.Allocator) !void {
+        for (s.windows.items) |w| if (w == wid) return;
+        try s.windows.append(allocator, wid);
+    }
+
+    pub fn remove(s: *State, wid: WindowId, allocator: std.mem.Allocator) void {
+        _ = allocator;
+        for (s.windows.items, 0..) |w, i| {
+            if (w == wid) {
+                _ = s.windows.swapRemove(i);
+                return;
+            }
+        }
+    }
+
+    pub fn windowCount(s: *const State) usize {
+        return s.windows.items.len;
+    }
+
+    pub fn firstWid(s: *const State) ?WindowId {
+        return if (s.windows.items.len > 0) s.windows.items[0] else null;
+    }
+
+    pub fn lastWid(s: *const State) ?WindowId {
+        const n = s.windows.items.len;
+        return if (n > 0) s.windows.items[n - 1] else null;
+    }
+
+    pub fn cycleFocus(s: *const State, wid: WindowId, forward: bool) ?WindowId {
+        const items = s.windows.items;
+        if (items.len <= 1) return null;
+        for (items, 0..) |w, i| {
+            if (w != wid) continue;
+            const next = if (forward)
+                (i + 1) % items.len
+            else if (i == 0) items.len - 1 else i - 1;
+            return items[next];
+        }
+        return null;
+    }
+
+    pub fn setActive(s: *State, wid: WindowId) void {
+        for (s.windows.items, 0..) |w, i| {
+            if (w != wid) continue;
+            if (i == 0) return;
+            var j = i;
+            while (j > 0) : (j -= 1) s.windows.items[j] = s.windows.items[j - 1];
+            s.windows.items[0] = wid;
+            return;
+        }
+    }
+
+    pub fn replaceWid(s: *State, old: WindowId, new: WindowId) bool {
+        for (s.windows.items) |*w| {
+            if (w.* == old) {
+                w.* = new;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    pub fn swapWids(s: *State, a: WindowId, b: WindowId) bool {
+        if (a == b) return false;
+        var ai: ?usize = null;
+        var bi: ?usize = null;
+        for (s.windows.items, 0..) |w, i| {
+            if (w == a) ai = i;
+            if (w == b) bi = i;
+        }
+        const ia = ai orelse return false;
+        const ib = bi orelse return false;
+        const tmp = s.windows.items[ia];
+        s.windows.items[ia] = s.windows.items[ib];
+        s.windows.items[ib] = tmp;
+        return true;
+    }
+
+    pub fn computeLayout(
+        s: *const State,
+        frame: Frame,
+        _inner_gap: f64,
+        out: *std.ArrayList(LayoutEntry),
+        allocator: std.mem.Allocator,
+    ) !void {
+        _ = _inner_gap;
+        for (s.windows.items) |wid| {
+            try out.append(allocator, .{ .wid = wid, .frame = frame });
+        }
+    }
+};

--- a/src/tiling/monocle.zig
+++ b/src/tiling/monocle.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
 const WindowId = @import("../window.zig").WindowId;
 const Frame = @import("../window.zig").Window.Frame;
-const LayoutEntry = @import("bsp.zig").LayoutEntry;
+const bsp = @import("bsp.zig");
+const LayoutEntry = bsp.LayoutEntry;
+const InsertOptions = bsp.InsertOptions;
 
 pub const State = struct {
     windows: std.ArrayListUnmanaged(WindowId) = .empty,
@@ -16,13 +18,12 @@ pub const State = struct {
 
     // ── Common interface ──────────────────────────────────────────────────────
 
-    pub fn insert(s: *State, wid: WindowId, allocator: std.mem.Allocator) !void {
+    pub fn insert(s: *State, wid: WindowId, _: InsertOptions, allocator: std.mem.Allocator) !void {
         for (s.windows.items) |w| if (w == wid) return;
         try s.windows.append(allocator, wid);
     }
 
-    pub fn remove(s: *State, wid: WindowId, allocator: std.mem.Allocator) void {
-        _ = allocator;
+    pub fn remove(s: *State, wid: WindowId, _: std.mem.Allocator) void {
         for (s.windows.items, 0..) |w, i| {
             if (w == wid) {
                 _ = s.windows.swapRemove(i);
@@ -40,8 +41,7 @@ pub const State = struct {
     }
 
     pub fn lastWid(s: *const State) ?WindowId {
-        const n = s.windows.items.len;
-        return if (n > 0) s.windows.items[n - 1] else null;
+        return if (s.windows.items.len > 0) s.windows.items[s.windows.items.len - 1] else null;
     }
 
     pub fn cycleFocus(s: *const State, wid: WindowId, forward: bool) ?WindowId {
@@ -61,9 +61,7 @@ pub const State = struct {
         for (s.windows.items, 0..) |w, i| {
             if (w != wid) continue;
             if (i == 0) return;
-            var j = i;
-            while (j > 0) : (j -= 1) s.windows.items[j] = s.windows.items[j - 1];
-            s.windows.items[0] = wid;
+            std.mem.rotate(WindowId, s.windows.items[0 .. i + 1], i);
             return;
         }
     }
@@ -85,6 +83,7 @@ pub const State = struct {
         for (s.windows.items, 0..) |w, i| {
             if (w == a) ai = i;
             if (w == b) bi = i;
+            if (ai != null and bi != null) break;
         }
         const ia = ai orelse return false;
         const ib = bi orelse return false;
@@ -97,11 +96,10 @@ pub const State = struct {
     pub fn computeLayout(
         s: *const State,
         frame: Frame,
-        _inner_gap: f64,
+        _: f64,
         out: *std.ArrayList(LayoutEntry),
         allocator: std.mem.Allocator,
     ) !void {
-        _ = _inner_gap;
         for (s.windows.items) |wid| {
             try out.append(allocator, .{ .wid = wid, .frame = frame });
         }


### PR DESCRIPTION
This allows us to use DS that's spesific to the layout, avoiding creating a suboptimal general DS decision since every layouting algoritm/way has its own needs