### PR TITLE
fix: focus active app with SkyLight instead of NSWorkspace

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1844,6 +1844,10 @@ export fn bw_ax_focus_window(pid: i32, wid: u32) bool {
         _ = c.usleep(same_process_focus_delay_us);
     }
 
+    if (setFrontProcessViaSkylight(pid, wid)) return true;
+
+    // Fallback for when the private SkyLight symbols are unavailable. Modern
+    // macOS largely ignores this from a background agent, but it is harmless.
     const NSRunningApplication = objc.getClass("NSRunningApplication") orelse return true;
     const app = NSRunningApplication.msgSend(objc.Object, "runningApplicationWithProcessIdentifier:", .{pid});
     if (app.value != null) {
@@ -1851,6 +1855,53 @@ export fn bw_ax_focus_window(pid: i32, wid: u32) bool {
         _ = app.msgSend(bool, "activateWithOptions:", .{@as(usize, 2)});
     }
     return true;
+}
+
+/// Carbon PSN lookup. Deprecated since 10.9 but still exported and functional;
+/// not present in the aggregated C header surface, so declared directly.
+extern fn GetProcessForPID(pid: i32, psn: *skylight.ProcessSerialNumber) c_int;
+
+/// kCPSUserGenerated — marks the activation as user-driven so the WindowServer
+/// honors the focus change. Not a public constant; value from CoreGraphics CPS.
+const kCPSUserGenerated: u32 = 0x200;
+
+/// Move keyboard focus by making the target the front process and posting the
+/// two focus event records SkyLight expects (yabai's mechanism). This actually
+/// moves input focus, unlike NSRunningApplication.activate on modern macOS.
+/// Returns false if the SkyLight symbols or the process's PSN are unavailable.
+fn setFrontProcessViaSkylight(pid: i32, wid: u32) bool {
+    const sky = g_sky orelse return false;
+    const set_front = sky.setFrontProcessWithOptions orelse return false;
+    const post_event = sky.postEventRecordTo orelse return false;
+
+    var psn: skylight.ProcessSerialNumber = .{ .high = 0, .low = 0 };
+    if (GetProcessForPID(pid, &psn) != 0) {
+        log.debug("focus activation: GetProcessForPID failed pid={d}, using Cocoa fallback", .{pid});
+        return false;
+    }
+
+    if (set_front(&psn, wid, kCPSUserGenerated) != 0) {
+        log.debug("focus activation: SLPSSetFrontProcessWithOptions failed pid={d} wid={d}", .{ pid, wid });
+        return false;
+    }
+
+    var focus_event = focusEventRecord(wid, 0x01);
+    _ = post_event(&psn, &focus_event);
+    var raise_event = focusEventRecord(wid, 0x02);
+    _ = post_event(&psn, &raise_event);
+    return true;
+}
+
+/// One 0xF8-byte SkyLight event record targeting `wid`. `kind` is 0x01 for the
+/// focus record and 0x02 for the raise record. Byte offsets are SkyLight's.
+fn focusEventRecord(wid: u32, kind: u8) [0xf8]u8 {
+    var bytes = [_]u8{0} ** 0xf8;
+    bytes[0x04] = 0xf8;
+    bytes[0x08] = kind;
+    bytes[0x3a] = 0x10;
+    @memset(bytes[0x20..0x30], 0xFF);
+    std.mem.writeInt(u32, bytes[0x3c..0x40], wid, .little);
+    return bytes;
 }
 
 fn manageStateForWindow(pid: i32, wid: u32) u8 {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1844,17 +1844,7 @@ export fn bw_ax_focus_window(pid: i32, wid: u32) bool {
         _ = c.usleep(same_process_focus_delay_us);
     }
 
-    if (setFrontProcessViaSkylight(pid, wid)) return true;
-
-    // Fallback for when the private SkyLight symbols are unavailable. Modern
-    // macOS largely ignores this from a background agent, but it is harmless.
-    const NSRunningApplication = objc.getClass("NSRunningApplication") orelse return true;
-    const app = NSRunningApplication.msgSend(objc.Object, "runningApplicationWithProcessIdentifier:", .{pid});
-    if (app.value != null) {
-        // NSApplicationActivateIgnoringOtherApps == 2.
-        _ = app.msgSend(bool, "activateWithOptions:", .{@as(usize, 2)});
-    }
-    return true;
+    return setFrontProcessViaSkylight(pid, wid);
 }
 
 /// Carbon PSN lookup. Deprecated since 10.9 but still exported and functional;
@@ -1876,7 +1866,7 @@ fn setFrontProcessViaSkylight(pid: i32, wid: u32) bool {
 
     var psn: skylight.ProcessSerialNumber = .{ .high = 0, .low = 0 };
     if (GetProcessForPID(pid, &psn) != 0) {
-        log.debug("focus activation: GetProcessForPID failed pid={d}, using Cocoa fallback", .{pid});
+        log.debug("focus activation: GetProcessForPID failed pid={d}", .{pid});
         return false;
     }
 

--- a/src/skylight.zig
+++ b/src/skylight.zig
@@ -16,10 +16,22 @@ pub const CGSize = extern struct {
     height: f64,
 };
 
+pub const ProcessSerialNumber = extern struct {
+    high: u32,
+    low: u32,
+};
+
+pub const SetFrontProcessFn = *const fn (*ProcessSerialNumber, u32, u32) callconv(.c) c_int;
+pub const PostEventRecordFn = *const fn (*ProcessSerialNumber, [*]u8) callconv(.c) c_int;
+
 pub const SkyLight = struct {
     handle: *anyopaque,
     mainConnectionID: *const fn () callconv(.c) c_int,
     getWindowBounds: *const fn (c_int, u32, *CGRect) callconv(.c) c_int,
+    /// Private focus-activation symbols (yabai's path). Optional: if either is
+    /// missing the caller falls back to Cocoa activation.
+    setFrontProcessWithOptions: ?SetFrontProcessFn,
+    postEventRecordTo: ?PostEventRecordFn,
 
     pub fn init() ?SkyLight {
         var lib = std.DynLib.open("/System/Library/PrivateFrameworks/SkyLight.framework/SkyLight") catch {
@@ -45,12 +57,20 @@ pub const SkyLight = struct {
             return null;
         };
 
+        const set_front = lib.lookup(SetFrontProcessFn, "SLPSSetFrontProcessWithOptions");
+        const post_event = lib.lookup(PostEventRecordFn, "SLPSPostEventRecordTo");
+        if (set_front == null or post_event == null) {
+            log.warn("SkyLight focus-activation symbols unavailable; using Cocoa activation fallback", .{});
+        }
+
         log.info("SkyLight.framework loaded", .{});
 
         return SkyLight{
             .handle = lib.inner.handle,
             .mainConnectionID = conn_id,
             .getWindowBounds = get_bounds,
+            .setFrontProcessWithOptions = set_front,
+            .postEventRecordTo = post_event,
         };
     }
 };


### PR DESCRIPTION
# Problem
When switching workspaces, sometimes `bobrwm` doesn't focus on the correct application. For example, if I have Ghostty in workspace 1 and Helium in workspace 2, switching from 1 to 2 keeps the active application as Ghostty, but only sometimes.

# Fix
Uses `SLPSSetFrontProcessWithOptions` as the first attempt to try and focus the correct application on workspace switch. This is behavior that Yabai uses because it also learned that when running as a background agent that `NSRunningApplication.activateWithOptions` is flaky/unreliable.

FWIW this is not reproducible when running `bobrwm` normally. It only happens when running as a daemon.