### PR TITLE
Hot config reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Config is loaded from (in order):
 
 If no config file is found, built-in defaults are used. See [`examples/config.zon`](examples/config.zon) for a full example.
 
+Press `Alt+Shift+R` (the default `reload_config` binding) to apply changes
+without restarting. If the file contains invalid ZON, bobrwm keeps the last valid configuration.
+Changing the number of workspaces still requires a restart; other settings,
+including keybinds, rules, layouts, gaps, animation, and dimming, reload live.
+
 ### Keybinds
 
 Map a key + modifiers to an action. Configured keybinds are merged with the
@@ -87,6 +92,7 @@ built-in defaults; use the same key + modifiers to override a default binding.
 | `toggle_split` | Toggle next split direction | — |
 | `toggle_fullscreen` | Toggle focused window fullscreen | — |
 | `toggle_float` | Toggle focused window floating | — |
+| `reload_config` | Reload the config file, keeping the current config if parsing fails | — |
 
 ### Gaps
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,18 @@ Config is loaded from (in order):
 If no config file is found, built-in defaults are used. See [`examples/config.zon`](examples/config.zon) for a full example.
 
 Press `Alt+Shift+R` (the default `reload_config` binding) to apply changes
-without restarting. If the file contains invalid ZON, bobrwm keeps the last valid configuration.
+without restarting. If the file contains invalid ZON, bobrwm keeps the last
+valid configuration and shows a temporary error in its menu-bar item; parser
+details remain in the error log.
+
+The same reload is available from the command line:
+
+```bash
+bobrwm reload-config
+```
+
+The command is silent on success and exits non-zero with an error message when
+the new config cannot be loaded.
 Changing the number of workspaces still requires a restart; other settings,
 including keybinds, rules, layouts, gaps, animation, and dimming, reload live.
 

--- a/examples/config.zon
+++ b/examples/config.zon
@@ -128,6 +128,9 @@
         // ctrl+left/right → traverse bobrwm workspaces; native Spaces handle the edge
         .{ .key = "left", .mods = .{ .ctrl = true }, .action = .focus_previous_workspace },
         .{ .key = "right", .mods = .{ .ctrl = true }, .action = .focus_next_workspace },
+
+        // alt+shift+r → reload this config after saving it
+        .{ .key = "r", .mods = .{ .alt = true, .shift = true }, .action = .reload_config },
     },
 
     // Per-app rules keyed by bundle identifier. Each field is optional:

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -109,7 +109,8 @@ pub fn run(result: Result) bool {
             return true;
         },
         .ipc => |cmd| {
-            runClient(cmd);
+            const exit_code = runClient(cmd);
+            if (exit_code != 0) std.process.exit(exit_code);
             return true;
         },
     }
@@ -168,6 +169,7 @@ const help_text =
     \\
     \\Window Commands (IPC):
     \\  retile                    Re-tile all windows on the active workspace
+    \\  reload-config             Reload config, keeping current config on failure
     \\  toggle-split              Cycle BSP split mode (auto, horizontal, vertical)
     \\  focus <direction>         Focus window in direction (left, right, up, down)
     \\  focus-workspace <n|prev|next>
@@ -240,14 +242,16 @@ fn runService(tail: ?[]const u8) void {
 
 // IPC client (sends command to running daemon)
 
-fn runClient(cmd: []const u8) void {
+fn runClient(cmd: []const u8) u8 {
     const started_ns = osutil.nanoTimestamp();
     var response_bytes: usize = 0;
+    var response_is_error = false;
+    var transport_failed = false;
 
     var path_buf: [128]u8 = undefined;
     const path = std.fmt.bufPrintSentinel(&path_buf, "/tmp/bobrwm_{d}.sock", .{std.c.getuid()}, 0) catch {
         writeStderr("error: socket path too long\n");
-        return;
+        return 1;
     };
 
     // Zig 0.16 removed the std.posix.{socket,connect,write,close,shutdown}
@@ -257,7 +261,7 @@ fn runClient(cmd: []const u8) void {
     const fd = std.c.socket(posix.AF.UNIX, posix.SOCK.STREAM, 0);
     if (fd < 0) {
         writeStderr("error: could not create socket\n");
-        return;
+        return 1;
     }
     defer _ = std.c.close(fd);
     const no_sigpipe: i32 = 1;
@@ -273,12 +277,12 @@ fn runClient(cmd: []const u8) void {
 
     if (std.c.connect(fd, @ptrCast(&addr), @sizeOf(posix.sockaddr.un)) != 0) {
         writeStderr("error: bobrwm is not running\n");
-        return;
+        return 1;
     }
 
     if (std.c.write(fd, cmd.ptr, cmd.len) < 0) {
         writeStderr("error: write failed\n");
-        return;
+        return 1;
     }
     _ = std.c.shutdown(fd, std.c.SHUT.WR);
 
@@ -290,21 +294,33 @@ fn runClient(cmd: []const u8) void {
         }};
         const ready = posix.poll(&poll_fds, 2000) catch {
             writeStderr("error: IPC poll failed\n");
+            transport_failed = true;
             break;
         };
         if (ready == 0) {
             writeStderr("error: IPC response timeout\n");
             log.warn("ipc client timeout waiting for response cmd={s}", .{cmd});
+            transport_failed = true;
             break;
         }
 
         var buf: [4096]u8 = undefined;
-        const n = posix.read(fd, &buf) catch break;
+        const n = posix.read(fd, &buf) catch {
+            writeStderr("error: IPC response read failed\n");
+            transport_failed = true;
+            break;
+        };
         if (n == 0) break;
+        if (response_bytes == 0) response_is_error = std.mem.startsWith(u8, buf[0..n], "err:");
         response_bytes += n;
-        writeStdout(buf[0..n]);
+        if (response_is_error) {
+            writeStderr(buf[0..n]);
+        } else {
+            writeStdout(buf[0..n]);
+        }
     }
 
     const elapsed_ms = @divTrunc(osutil.nanoTimestamp() - started_ns, std.time.ns_per_ms);
     log.debug("[trace] ipc client completed bytes={} elapsed_ms={}", .{ response_bytes, elapsed_ms });
+    return if (transport_failed or response_is_error) 1 else 0;
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -126,6 +126,7 @@ pub const Action = enum(u8) {
     swap_up = 35,
     swap_down = 36,
     center_float = 37,
+    reload_config = 38,
 
     // Every Action must map 1:1 to an EventKind (hk_ prefixed).
     comptime {
@@ -221,6 +222,8 @@ const default_keybinds = blk: {
         .{ .key = "j", .mods = .{ .alt = true, .shift = true }, .action = .swap_down },
         .{ .key = "k", .mods = .{ .alt = true, .shift = true }, .action = .swap_up },
         .{ .key = "l", .mods = .{ .alt = true, .shift = true }, .action = .swap_right },
+        // alt+shift+r → reload config
+        .{ .key = "r", .mods = .{ .alt = true, .shift = true }, .action = .reload_config },
     };
 
     break :blk binds[0..binds.len].*;
@@ -325,32 +328,33 @@ fn isDefaultKeybindSlice(keybinds: []const Keybind) bool {
 // Loading
 
 pub fn load(allocator: std.mem.Allocator, explicit_path: ?[]const u8) Config {
-    if (explicit_path) |p| {
-        return loadFromPath(allocator, p) orelse {
-            log.err("failed to load config from {s}, using defaults", .{p});
-            return .{};
-        };
-    }
-
-    // XDG_CONFIG_HOME / ~/.config
-    var path_buf: [2048]u8 = undefined;
-    const path = blk: {
-        if (osutil.getenv("XDG_CONFIG_HOME")) |config_home| {
-            break :blk std.fmt.bufPrint(&path_buf, "{s}/bobrwm/config.zon", .{config_home}) catch return .{};
-        }
-
-        const home = osutil.getenv("HOME") orelse return .{};
-        break :blk std.fmt.bufPrint(&path_buf, "{s}/.config/bobrwm/config.zon", .{home}) catch return .{};
-    };
-    std.debug.assert(path.len > 0);
+    const path = resolvePath(allocator, explicit_path) catch return .{};
+    defer allocator.free(path);
 
     return loadFromPath(allocator, path) orelse {
-        log.info("no config file found, using defaults", .{});
+        if (explicit_path != null) {
+            log.err("failed to load config from {s}, using defaults", .{path});
+        } else {
+            log.info("no config file found, using defaults", .{});
+        }
         return .{};
     };
 }
 
-fn loadFromPath(allocator: std.mem.Allocator, path: []const u8) ?Config {
+/// Resolve the configured path even when it does not exist yet, allowing the
+/// daemon to notice a config file created after startup.
+pub fn resolvePath(allocator: std.mem.Allocator, explicit_path: ?[]const u8) ![:0]u8 {
+    if (explicit_path) |path| return allocator.dupeZ(u8, path);
+
+    if (osutil.getenv("XDG_CONFIG_HOME")) |config_home| {
+        return std.fmt.allocPrintSentinel(allocator, "{s}/bobrwm/config.zon", .{config_home}, 0);
+    }
+
+    const home = osutil.getenv("HOME") orelse return error.MissingHome;
+    return std.fmt.allocPrintSentinel(allocator, "{s}/.config/bobrwm/config.zon", .{home}, 0);
+}
+
+pub fn loadFromPath(allocator: std.mem.Allocator, path: []const u8) ?Config {
     log.info("loading config from {s}", .{path});
 
     // libc-based read; std.fs.cwd was removed in Zig 0.16. Caller paths
@@ -551,6 +555,10 @@ test "default_keybinds" {
         try t.expect(std.mem.eql(u8, key, default_keybinds[i].key));
         try t.expect(default_keybinds[i].mods.alt and default_keybinds[i].mods.shift);
     }
+
+    try t.expectEqual(Action.reload_config, default_keybinds[29].action);
+    try t.expect(std.mem.eql(u8, "r", default_keybinds[29].key));
+    try t.expect(default_keybinds[29].mods.alt and default_keybinds[29].mods.shift);
 }
 
 test "buildKeybinds merges custom keybinds with defaults" {
@@ -638,7 +646,7 @@ test "loadFromPath: examples/config.zon" {
     const cfg = loadFromPath(arena.allocator(), "examples/config.zon") orelse
         return error.TestUnexpectedResult;
 
-    try t.expectEqual(@as(usize, 30), cfg.keybinds.len);
+    try t.expectEqual(@as(usize, 31), cfg.keybinds.len);
 
     try t.expectEqual(Action.focus_workspace, cfg.keybinds[0].action);
     try t.expectEqual(@as(u8, 1), cfg.keybinds[0].arg);

--- a/src/dim.zig
+++ b/src/dim.zig
@@ -23,7 +23,8 @@ const config = @import("config.zig");
 
 const log = std.log.scoped(.dim);
 
-/// Set from `config.dimmed_inactive` at startup. When false, apply() is a no-op.
+/// Set from `config.dimmed_inactive` at startup and on config reload.
+/// When false, apply() is a no-op.
 pub var enabled: bool = false;
 /// Overlay opacity in [0, 1] (0 = transparent, 1 = fully black).
 pub var level: f64 = 0.35;
@@ -68,6 +69,10 @@ var slot_count: usize = 0; // number of lazily created panels
 pub fn configure(cfg: config.DimConfig) void {
     enabled = cfg.enabled;
     level = std.math.clamp(@as(f64, cfg.level), 0.0, 1.0);
+    for (slots[0..slot_count]) |*slot| {
+        slot.panel.msgSend(void, "setAlphaValue:", .{level});
+    }
+    if (!enabled) resetAll();
 }
 
 /// Show/position overlays so every entry except a focused window is dimmed.
@@ -222,8 +227,8 @@ fn createPanel() ?objc.Object {
         }
     }
 
-    // Opacity is fixed for the process lifetime (set once from config), so it
-    // is applied here rather than on every apply().
+    // configure() updates existing panels when config is hot-reloaded; newly
+    // allocated panels start at the current level here.
     panel.msgSend(void, "setAlphaValue:", .{level});
 
     const collection_behavior =

--- a/src/event.zig
+++ b/src/event.zig
@@ -35,6 +35,7 @@ pub const EventKind = enum(u8) {
     hk_swap_up = 35,
     hk_swap_down = 36,
     hk_center_float = 37,
+    hk_reload_config = 38,
 };
 
 pub const Event = extern struct {

--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -12,6 +12,7 @@ pub const DispatchFn = *const fn (cmd: []const u8, client_fd: posix.socket_t) vo
 
 pub const IpcCommand = union(enum) {
     retile,
+    reload_config,
     toggle_split,
     focus: FocusDir,
     focus_workspace: WorkspaceTarget,
@@ -51,6 +52,7 @@ pub const IpcCommand = union(enum) {
     pub fn parse(cmd: []const u8) ?IpcCommand {
         // Exact-match commands (no arguments)
         if (std.mem.eql(u8, cmd, "retile")) return .retile;
+        if (std.mem.eql(u8, cmd, "reload-config")) return .reload_config;
         if (std.mem.eql(u8, cmd, "toggle-split")) return .toggle_split;
         if (std.mem.eql(u8, cmd, "bsp equalize")) return .bsp_equalize;
         if (std.mem.eql(u8, cmd, "bsp balance")) return .bsp_balance;
@@ -264,6 +266,13 @@ test "parse query format" {
     try t.expectEqual(IpcCommand{ .query_displays = .json }, IpcCommand.parse("query displays --json").?);
     try t.expectEqual(IpcCommand{ .query_apps = .json }, IpcCommand.parse("query apps --json").?);
     try t.expectEqual(@as(?IpcCommand, null), IpcCommand.parse("query windows --json extra"));
+}
+
+test "parse reload config" {
+    const t = std.testing;
+
+    try t.expectEqual(IpcCommand.reload_config, IpcCommand.parse("reload-config").?);
+    try t.expectEqual(@as(?IpcCommand, null), IpcCommand.parse("reload-config extra"));
 }
 
 test "parse focus workspace target" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -2184,13 +2184,34 @@ fn applyReloadedConfig(next: ConfigRuntime) void {
     log.info("config reloaded from {s}", .{g_config_path.?});
 }
 
-fn reloadConfig() void {
-    const path = g_config_path orelse return;
+var g_config_error_generation: usize = 0;
+
+fn restoreStatusBarAfterConfigError(context: ?*anyopaque) callconv(.c) void {
+    const generation = @intFromPtr(context orelse return);
+    if (generation == g_config_error_generation) updateStatusBar();
+}
+
+fn notifyConfigReloadFailed() void {
+    statusbar.setMessage("⚠ Config reload failed");
+    g_config_error_generation +%= 1;
+    if (g_config_error_generation == 0) g_config_error_generation = 1;
+    c.dispatch_after_f(
+        c.dispatch_time(c.DISPATCH_TIME_NOW, 4 * c.NSEC_PER_SEC),
+        cg_extra.dispatch_get_main_queue(),
+        @ptrFromInt(g_config_error_generation),
+        restoreStatusBarAfterConfigError,
+    );
+}
+
+fn reloadConfig() bool {
+    const path = g_config_path orelse return false;
     const next = ConfigRuntime.init(g_allocator, path, false) catch |err| {
         log.err("config reload failed, keeping current config: {}", .{err});
-        return;
+        notifyConfigReloadFailed();
+        return false;
     };
     applyReloadedConfig(next);
+    return true;
 }
 
 fn setRolePolling(enabled: bool) void {
@@ -3289,7 +3310,7 @@ fn handleEvent(ev: *const event_mod.Event) void {
             const focused = ws.focused_wid orelse return;
             centerFloatingWindow(focused);
         },
-        .hk_reload_config => reloadConfig(),
+        .hk_reload_config => _ = reloadConfig(),
         .hk_toggle_dimming => {
             const on = dim.toggle();
             log.info("hotkey: dimming {s}", .{if (on) "on" else "off"});
@@ -6009,6 +6030,11 @@ fn ipcDispatch(cmd: []const u8, client_fd: posix.socket_t) void {
         .retile => {
             retile();
             ipc.writeResponse(client_fd, "ok\n");
+        },
+        .reload_config => {
+            if (!reloadConfig()) {
+                ipc.writeResponse(client_fd, "err: config reload failed; current config kept\n");
+            }
         },
         .toggle_split => {
             g_bsp_split_mode = switch (g_bsp_split_mode) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1361,6 +1361,8 @@ var g_focus_retries: FocusRetryMap = undefined;
 var g_workspace_observer: ?objc.Object = null;
 var g_ipc: ipc.Server = undefined;
 var g_config: config_mod.Config = .{};
+var g_config_runtime: ?ConfigRuntime = null;
+var g_config_path: ?[:0]const u8 = null;
 var g_drag_preview: DragPreviewState = .{};
 var g_mouse_left_down = false;
 var g_drag_reconcile_on_drop = false;
@@ -1397,6 +1399,31 @@ var g_cleanup_pending_pid_count: usize = 0;
 
 var g_animator: animation_mod.Animator = undefined;
 var g_animator_source: c.dispatch_source_t = null;
+
+const ConfigRuntime = struct {
+    arena: std.heap.ArenaAllocator,
+    config: config_mod.Config,
+    keybind_table: config_mod.KeybindTable,
+
+    fn init(parent_allocator: std.mem.Allocator, path: ?[]const u8, use_defaults_on_error: bool) !ConfigRuntime {
+        var arena = std.heap.ArenaAllocator.init(parent_allocator);
+        errdefer arena.deinit();
+        const allocator = arena.allocator();
+        const config = if (path) |p| blk: {
+            break :blk config_mod.loadFromPath(allocator, p) orelse {
+                if (!use_defaults_on_error) return error.InvalidConfig;
+                break :blk config_mod.Config{};
+            };
+        } else config_mod.Config{};
+        const keybind_table = try config_mod.KeybindTable.init(allocator, &config);
+        return .{ .arena = arena, .config = config, .keybind_table = keybind_table };
+    }
+
+    fn deinit(self: *ConfigRuntime) void {
+        self.arena.deinit();
+        self.* = undefined;
+    }
+};
 
 fn shouldHandleWorkspaceEvent(last_event_at_s: *f64) bool {
     std.debug.assert(last_event_at_s.* >= 0);
@@ -2108,6 +2135,64 @@ fn rolePollTimerTick(context: ?*anyopaque) callconv(.c) void {
     bw_emit_event(shim.BW_EVENT_ROLE_POLL_TICK, 0, 0);
 }
 
+fn rebuildTilingStatesForConfig() void {
+    destroyAllTilingStates();
+    for (g_workspaces.workspaces[0..g_workspaces.workspace_count]) |*ws| {
+        for (ws.windows.items) |wid| {
+            const win = g_store.get(wid) orelse continue;
+            // Workspace lists contain only tab-group leaders; a leader may be
+            // "suppressed" while another native tab is active but still owns
+            // the group's one layout slot.
+            if (win.mode != .tiled) continue;
+            insertIntoTiling(ws.id, wid);
+        }
+        if (ws.focused_wid) |focused_wid| setTilingActive(ws.id, focused_wid);
+    }
+}
+
+fn applyReloadedConfig(next: ConfigRuntime) void {
+    var replacement = next;
+    replacement.config.applyKeybinds(&replacement.keybind_table);
+
+    var previous = g_config_runtime.?;
+    const layout_changed = previous.config.layout != replacement.config.layout;
+    g_config_runtime = replacement;
+    g_config = replacement.config;
+    g_bsp_split_mode = g_config.bsp_split;
+    g_animator.finishAll();
+    g_animator.init(g_config.animation);
+    dim.configure(g_config.dimmed_inactive);
+
+    for (g_workspaces.workspaces[0..g_workspaces.workspace_count], 0..) |*ws, i| {
+        ws.name = if (i < g_config.workspace_names.len) g_config.workspace_names[i] else "";
+    }
+    if (g_config.workspace_names.len > 0 and g_config.workspace_names.len != g_workspaces.workspace_count) {
+        log.warn("config reload cannot change workspace count ({d} running, {d} configured); restart to apply the new count", .{
+            g_workspaces.workspace_count,
+            g_config.workspace_names.len,
+        });
+    }
+
+    // Preserve BSP topology and runtime split edits for ordinary config saves.
+    // Only changing the layout algorithm requires reconstructing state.
+    if (layout_changed) rebuildTilingStatesForConfig();
+    updateStatusBar();
+    retile();
+    if (dim.enabled) pushDimSnapshot();
+
+    previous.deinit();
+    log.info("config reloaded from {s}", .{g_config_path.?});
+}
+
+fn reloadConfig() void {
+    const path = g_config_path orelse return;
+    const next = ConfigRuntime.init(g_allocator, path, false) catch |err| {
+        log.err("config reload failed, keeping current config: {}", .{err});
+        return;
+    };
+    applyReloadedConfig(next);
+}
+
 fn setRolePolling(enabled: bool) void {
     if (!enabled) {
         if (g_role_poll_source) |source| {
@@ -2293,11 +2378,9 @@ fn bw_hotkey_mouse_up() void {
 }
 
 /// Accept the keybind table from config. Stores a reference to caller-owned
-/// storage instead of copying, so the table has no fixed size cap. Must be
-/// called on the main thread before the hotkey event tap is installed.
+/// storage instead of copying, so the table has no fixed size cap. Called on
+/// the main thread both at startup and when config is hot-reloaded.
 export fn bw_set_keybinds(binds: ?[*]const shim.bw_keybind, count: u32) void {
-    std.debug.assert(g_tap_port == null);
-
     const src = binds orelse {
         g_hotkey_bindings = &.{};
         return;
@@ -2340,13 +2423,14 @@ pub fn main(init: std.process.Init.Minimal) !void {
     defer deinitAxStrings();
 
     // -- Config --
-    var config_arena = std.heap.ArenaAllocator.init(g_allocator);
-    defer config_arena.deinit();
-    g_config = config_mod.load(config_arena.allocator(), cli.configPath(result));
+    const config_path = config_mod.resolvePath(g_allocator, cli.configPath(result)) catch null;
+    defer if (config_path) |path| g_allocator.free(path);
+    g_config_path = config_path;
+    g_config_runtime = try ConfigRuntime.init(g_allocator, config_path, true);
+    defer g_config_runtime.?.deinit();
+    g_config = g_config_runtime.?.config;
     g_bsp_split_mode = g_config.bsp_split;
-    var keybind_table = try config_mod.KeybindTable.init(config_arena.allocator(), &g_config);
-    defer keybind_table.deinit(config_arena.allocator());
-    g_config.applyKeybinds(&keybind_table);
+    g_config.applyKeybinds(&g_config_runtime.?.keybind_table);
     g_animator.init(g_config.animation);
 
     // Inactive-window dimming via SkyLight (SLSSetWindowListBrightness).
@@ -3205,6 +3289,7 @@ fn handleEvent(ev: *const event_mod.Event) void {
             const focused = ws.focused_wid orelse return;
             centerFloatingWindow(focused);
         },
+        .hk_reload_config => reloadConfig(),
         .hk_toggle_dimming => {
             const on = dim.toggle();
             log.info("hotkey: dimming {s}", .{if (on) "on" else "off"});

--- a/src/statusbar.zig
+++ b/src/statusbar.zig
@@ -116,6 +116,12 @@ pub fn setTitle(name: []const u8, id: u8) void {
     setTitleMulti(&.{.{ .name = name, .id = id, .focused = true }});
 }
 
+/// Temporarily replace the workspace title with a caller-managed status
+/// message. AppKit copies the NSString, so the input need not outlive the call.
+pub fn setMessage(message: [*:0]const u8) void {
+    g_button.msgSend(void, "setTitle:", .{nsString(message)});
+}
+
 fn nsString(str: [*:0]const u8) objc.Object {
     const NSString = objc.getClass("NSString") orelse
         @panic("NSString class not found");


### PR DESCRIPTION
Adds an IPC and keybind command to reload the config. If it fails, it'll keep the old config that it launched it, will still fail to launch if the config is completely invalid. Updates the status bar if the config failed.