### PR TITLE
statusbar: add workspace and config menu actions

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -168,6 +168,13 @@ const WorkspaceTraversalDirection = enum {
     next,
 };
 
+pub const StatusBarAction = union(enum) {
+    open_config,
+    previous_workspace,
+    next_workspace,
+    workspace: workspace_mod.WorkspaceId,
+};
+
 const HotkeyEvent = struct {
     kind: u8,
     arg: u32,
@@ -2176,6 +2183,7 @@ fn applyReloadedConfig(next: ConfigRuntime) void {
     // Preserve BSP topology and runtime split edits for ordinary config saves.
     // Only changing the layout algorithm requires reconstructing state.
     if (layout_changed) rebuildTilingStatesForConfig();
+    statusbar.updateWorkspaceMenu(g_workspaces.workspaces[0..g_workspaces.workspace_count]);
     updateStatusBar();
     retile();
     if (dim.enabled) pushDimSnapshot();
@@ -2450,6 +2458,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
     g_config_runtime = try ConfigRuntime.init(g_allocator, config_path, true);
     defer g_config_runtime.?.deinit();
     g_config = g_config_runtime.?.config;
+
     g_bsp_split_mode = g_config.bsp_split;
     g_config.applyKeybinds(&g_config_runtime.?.keybind_table);
     g_animator.init(g_config.animation);
@@ -2573,8 +2582,9 @@ pub fn main(init: std.process.Init.Minimal) !void {
     refreshRolePolling();
     observeDiscoveredApps();
 
-    // -- Status bar (zig-objc) --
-    statusbar.init();
+    // Status bar (zig-objc) --
+    statusbar.init(g_workspaces.workspaces[0..g_workspaces.workspace_count]);
+    defer statusbar.deinit();
     updateStatusBar();
 
     // -- Enter NSApp run loop --
@@ -2692,6 +2702,44 @@ pub fn bw_will_quit() void {
 /// Retile — called from BWStatusBarDelegate.retile:.
 pub fn bw_retile() void {
     retile();
+}
+
+/// Dispatch a BWStatusBarDelegate action on the main thread.
+pub fn bw_status_bar_action(action: StatusBarAction) void {
+    switch (action) {
+        .open_config => openConfigFile(),
+        .previous_workspace => switchAdjacentWorkspace(.previous),
+        .next_workspace => switchAdjacentWorkspace(.next),
+        .workspace => |workspace_id| switchWorkspace(workspace_id),
+    }
+}
+
+fn openConfigFile() void {
+    const path = g_config_path orelse {
+        log.warn("cannot open config file because its path could not be resolved", .{});
+        return;
+    };
+    const NSWorkspace = objc.getClass("NSWorkspace") orelse return;
+    const NSString = objc.getClass("NSString") orelse return;
+    const NSURL = objc.getClass("NSURL") orelse return;
+    const workspace = NSWorkspace.msgSend(objc.Object, "sharedWorkspace", .{});
+    if (workspace.value == null) {
+        log.warn("cannot open config file at {s}", .{path});
+        return;
+    }
+    const ns_path = NSString.msgSend(objc.Object, "stringWithUTF8String:", .{path.ptr});
+    if (ns_path.value == null) {
+        log.warn("cannot open config file at {s}", .{path});
+        return;
+    }
+    const url = NSURL.msgSend(objc.Object, "fileURLWithPath:", .{ns_path});
+    if (url.value == null) {
+        log.warn("cannot open config file at {s}", .{path});
+        return;
+    }
+    if (!workspace.msgSend(bool, "openURL:", .{url})) {
+        log.warn("failed to open config file at {s}", .{path});
+    }
 }
 
 fn tilingStatePtr(workspace_id: u8) *?tiling.State {

--- a/src/objc_classes.zig
+++ b/src/objc_classes.zig
@@ -3,7 +3,7 @@
 //! Three BW* classes are registered with the ObjC runtime via zig-objc's
 //! `allocateClassPair` / `addMethod` helpers:
 //!
-//!   - `BWStatusBarDelegate` — Retile / Quit menu actions
+//!   - `BWStatusBarDelegate` — menu actions
 //!   - `BWObserver` — NSWorkspace + NSApplication notification target
 //!   - `BWLaunchGate` — per-pid KVO gate that defers app-launched events
 //!     until the process is finished launching AND has Regular activation
@@ -42,11 +42,34 @@ fn registerStatusBarDelegate() void {
     var cls = objc.allocateClassPair(NSObject, "BWStatusBarDelegate").?;
     _ = cls.addMethod("retile:", statusBarRetile);
     _ = cls.addMethod("quit:", statusBarQuit);
+    _ = cls.addMethod("openConfigFile:", statusBarOpenConfig);
+    _ = cls.addMethod("nextWorkspace:", statusBarNextWorkspace);
+    _ = cls.addMethod("previousWorkspace:", statusBarPreviousWorkspace);
+    _ = cls.addMethod("switchToWorkspace:", statusBarSwitchToWorkspace);
     objc.registerClassPair(cls);
 }
 
 fn statusBarRetile(_: c.id, _: c.SEL, _: c.id) callconv(.c) void {
     main.bw_retile();
+}
+
+fn statusBarOpenConfig(_: c.id, _: c.SEL, _: c.id) callconv(.c) void {
+    main.bw_status_bar_action(.open_config);
+}
+
+fn statusBarNextWorkspace(_: c.id, _: c.SEL, _: c.id) callconv(.c) void {
+    main.bw_status_bar_action(.next_workspace);
+}
+
+fn statusBarPreviousWorkspace(_: c.id, _: c.SEL, _: c.id) callconv(.c) void {
+    main.bw_status_bar_action(.previous_workspace);
+}
+
+fn statusBarSwitchToWorkspace(_: c.id, _: c.SEL, sender_id: c.id) callconv(.c) void {
+    const sender: objc.Object = .{ .value = sender_id };
+    const tag = sender.msgSend(i64, "tag", .{});
+    if (tag <= 0 or tag > std.math.maxInt(u8)) return;
+    main.bw_status_bar_action(.{ .workspace = @intCast(tag) });
 }
 
 fn statusBarQuit(_: c.id, _: c.SEL, _: c.id) callconv(.c) void {

--- a/src/statusbar.zig
+++ b/src/statusbar.zig
@@ -1,16 +1,24 @@
 //! macOS status bar (menu bar icon) via zig-objc.
 //!
-//! Displays the active workspace name/index and provides a menu
-//! with Retile and Quit actions (handled by BWStatusBarDelegate in objc_classes.zig).
+//! Displays active workspaces and provides workspace, configuration, Retile,
+//! and Quit actions through BWStatusBarDelegate in objc_classes.zig.
 
 const std = @import("std");
 const objc = @import("objc");
 
+const workspace_mod = @import("workspace.zig");
+
 const log = std.log.scoped(.statusbar);
 
-var g_button: objc.Object = undefined;
+var g_status_item: ?objc.Object = null;
+var g_button: ?objc.Object = null;
+var g_delegate: ?objc.Object = null;
+var g_workspace_menu: ?objc.Object = null;
 
-pub fn init() void {
+pub fn init(workspaces: []const workspace_mod.Workspace) void {
+    std.debug.assert(g_status_item == null);
+    std.debug.assert(workspaces.len > 0 and workspaces.len <= workspace_mod.max_workspaces);
+
     const NSStatusBar = objc.getClass("NSStatusBar") orelse return;
     const NSMenu = objc.getClass("NSMenu") orelse return;
     const NSMenuItem = objc.getClass("NSMenuItem") orelse return;
@@ -19,40 +27,126 @@ pub fn init() void {
     const bar = NSStatusBar.msgSend(objc.Object, "systemStatusBar", .{});
     // NSVariableStatusItemLength = -1
     const item = bar.msgSend(objc.Object, "statusItemWithLength:", .{@as(f64, -1.0)});
+    // NSStatusBar does not retain status items; this module owns it until deinit.
+    g_status_item = item.retain();
     g_button = item.msgSend(objc.Object, "button", .{});
 
     const delegate = BWDelegate.msgSend(objc.Object, "alloc", .{})
         .msgSend(objc.Object, "init", .{});
+    g_delegate = delegate;
 
     const menu = NSMenu.msgSend(objc.Object, "alloc", .{})
         .msgSend(objc.Object, "init", .{});
+    defer menu.msgSend(void, "release", .{});
 
-    const empty = nsString("");
+    addActionItem(menu, NSMenuItem, delegate, "Retile", "retile:");
+    addActionItem(menu, NSMenuItem, delegate, "Open Config File", "openConfigFile:");
+    addSeparator(menu, NSMenuItem);
+    addActionItem(menu, NSMenuItem, delegate, "Previous Workspace", "previousWorkspace:");
+    addActionItem(menu, NSMenuItem, delegate, "Next Workspace", "nextWorkspace:");
 
-    // Retile
-    const retile_item = NSMenuItem.msgSend(objc.Object, "alloc", .{})
+    const workspaces_item = NSMenuItem.msgSend(objc.Object, "alloc", .{})
         .msgSend(objc.Object, "initWithTitle:action:keyEquivalent:", .{
-        nsString("Retile"), objc.sel("retile:"), empty,
+        nsString("Workspaces"), @as(?*anyopaque, null), nsString(""),
     });
-    retile_item.msgSend(void, "setTarget:", .{delegate});
-    menu.msgSend(void, "addItem:", .{retile_item});
+    defer workspaces_item.msgSend(void, "release", .{});
 
-    // Separator
-    menu.msgSend(void, "addItem:", .{
-        NSMenuItem.msgSend(objc.Object, "separatorItem", .{}),
-    });
+    const workspace_menu = NSMenu.msgSend(objc.Object, "alloc", .{})
+        .msgSend(objc.Object, "initWithTitle:", .{nsString("Workspaces")});
+    defer workspace_menu.msgSend(void, "release", .{});
+    populateWorkspaceMenu(workspace_menu, NSMenuItem, delegate, workspaces);
 
-    // Quit
-    const quit_item = NSMenuItem.msgSend(objc.Object, "alloc", .{})
-        .msgSend(objc.Object, "initWithTitle:action:keyEquivalent:", .{
-        nsString("Quit bobrwm"), objc.sel("quit:"), empty,
-    });
-    quit_item.msgSend(void, "setTarget:", .{delegate});
-    menu.msgSend(void, "addItem:", .{quit_item});
+    workspaces_item.msgSend(void, "setSubmenu:", .{workspace_menu});
+    menu.msgSend(void, "addItem:", .{workspaces_item});
+    g_workspace_menu = workspace_menu;
+
+    addSeparator(menu, NSMenuItem);
+    addActionItem(menu, NSMenuItem, delegate, "Quit bobrwm", "quit:");
 
     item.msgSend(void, "setMenu:", .{menu});
 
     log.info("status bar created", .{});
+}
+
+pub fn deinit() void {
+    g_workspace_menu = null;
+    g_button = null;
+
+    if (g_status_item) |item| {
+        if (objc.getClass("NSStatusBar")) |NSStatusBar| {
+            const bar = NSStatusBar.msgSend(objc.Object, "systemStatusBar", .{});
+            bar.msgSend(void, "removeStatusItem:", .{item});
+        }
+        item.release();
+        g_status_item = null;
+    }
+
+    if (g_delegate) |delegate| {
+        delegate.msgSend(void, "release", .{});
+        g_delegate = null;
+    }
+}
+
+/// Refresh workspace labels after a configuration reload.
+pub fn updateWorkspaceMenu(workspaces: []const workspace_mod.Workspace) void {
+    std.debug.assert(workspaces.len > 0 and workspaces.len <= workspace_mod.max_workspaces);
+    const menu = g_workspace_menu orelse return;
+    const NSMenuItem = objc.getClass("NSMenuItem") orelse return;
+    const delegate = g_delegate orelse return;
+
+    menu.msgSend(void, "removeAllItems", .{});
+    populateWorkspaceMenu(menu, NSMenuItem, delegate, workspaces);
+}
+
+fn addActionItem(
+    menu: objc.Object,
+    NSMenuItem: objc.Class,
+    delegate: objc.Object,
+    title: [*:0]const u8,
+    action: [:0]const u8,
+) void {
+    const item = NSMenuItem.msgSend(objc.Object, "alloc", .{})
+        .msgSend(objc.Object, "initWithTitle:action:keyEquivalent:", .{
+        nsString(title), objc.sel(action), nsString(""),
+    });
+    defer item.msgSend(void, "release", .{});
+
+    item.msgSend(void, "setTarget:", .{delegate});
+    menu.msgSend(void, "addItem:", .{item});
+}
+
+fn addSeparator(menu: objc.Object, NSMenuItem: objc.Class) void {
+    menu.msgSend(void, "addItem:", .{
+        NSMenuItem.msgSend(objc.Object, "separatorItem", .{}),
+    });
+}
+
+fn populateWorkspaceMenu(
+    menu: objc.Object,
+    NSMenuItem: objc.Class,
+    delegate: objc.Object,
+    workspaces: []const workspace_mod.Workspace,
+) void {
+    for (workspaces) |workspace| {
+        std.debug.assert(workspace.id > 0 and workspace.id <= workspace_mod.max_workspaces);
+
+        var label_buffer: [128]u8 = undefined;
+        const label = if (workspace.name.len > 0)
+            std.fmt.bufPrintZ(&label_buffer, "Workspace {d}: {s}", .{ workspace.id, workspace.name }) catch
+                std.fmt.bufPrintZ(&label_buffer, "Workspace {d}", .{workspace.id}) catch unreachable
+        else
+            std.fmt.bufPrintZ(&label_buffer, "Workspace {d}", .{workspace.id}) catch unreachable;
+
+        const item = NSMenuItem.msgSend(objc.Object, "alloc", .{})
+            .msgSend(objc.Object, "initWithTitle:action:keyEquivalent:", .{
+            nsString(label.ptr), objc.sel("switchToWorkspace:"), nsString(""),
+        });
+        defer item.msgSend(void, "release", .{});
+
+        item.msgSend(void, "setTarget:", .{delegate});
+        item.msgSend(void, "setTag:", .{@as(i64, workspace.id)});
+        menu.msgSend(void, "addItem:", .{item});
+    }
 }
 
 pub const DisplayWorkspace = struct {
@@ -64,6 +158,7 @@ pub const DisplayWorkspace = struct {
 /// Update the status bar title to show all active workspaces across displays.
 /// Format: "ws1 | ws2 | ..." with the focused one marked with [brackets].
 pub fn setTitleMulti(workspaces: []const DisplayWorkspace) void {
+    const button = g_button orelse return;
     var buf: [256]u8 = undefined;
     var pos: usize = 0;
 
@@ -106,7 +201,7 @@ pub fn setTitleMulti(workspaces: []const DisplayWorkspace) void {
     if (pos >= buf.len) pos = buf.len - 1;
     buf[pos] = 0;
 
-    g_button.msgSend(void, "setTitle:", .{
+    button.msgSend(void, "setTitle:", .{
         nsString(@ptrCast(buf[0..pos :0])),
     });
 }
@@ -119,7 +214,8 @@ pub fn setTitle(name: []const u8, id: u8) void {
 /// Temporarily replace the workspace title with a caller-managed status
 /// message. AppKit copies the NSString, so the input need not outlive the call.
 pub fn setMessage(message: [*:0]const u8) void {
-    g_button.msgSend(void, "setTitle:", .{nsString(message)});
+    const button = g_button orelse return;
+    button.msgSend(void, "setTitle:", .{nsString(message)});
 }
 
 fn nsString(str: [*:0]const u8) objc.Object {


### PR DESCRIPTION
Add direct workspace selection, previous and next workspace actions, and a shortcut for opening the active configuration file.

Squashed and fixed #44 