### PR TITLE
fix: identify native tabs through AXWindow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,14 +86,17 @@ jobs:
           # the enclosing signature. --deep would sign them for us but applies
           # the app's options to every nested binary, which is why Apple
           # deprecated it.
-          for helper in bobrwm-cli:com.bobrwm.cli bobrwm-swipe:com.bobrwm.swipe; do
+          for helper in \
+            MacOS/bobrwm-cli:com.bobrwm.cli \
+            MacOS/bobrwm-swipe:com.bobrwm.swipe \
+            Frameworks/libbobrwm-ui.dylib:com.bobrwm.ui; do
             codesign \
               --force \
               --sign "$MACOS_CERTIFICATE_NAME" \
               --identifier "${helper#*:}" \
               --options runtime \
               --timestamp \
-              "$APP_PATH/Contents/MacOS/${helper%%:*}"
+              "$APP_PATH/Contents/${helper%%:*}"
           done
 
           # The app takes its identifier from CFBundleIdentifier.
@@ -114,6 +117,19 @@ jobs:
             "com.bobrwm.cli"
           test "$(codesign -dvv "$APP_PATH/Contents/MacOS/bobrwm-swipe" 2>&1 | sed -n 's/^Identifier=//p')" = \
             "com.bobrwm.swipe"
+          test "$(codesign -dvv "$APP_PATH/Contents/Frameworks/libbobrwm-ui.dylib" 2>&1 | sed -n 's/^Identifier=//p')" = \
+            "com.bobrwm.ui"
+
+          # --deep --strict accepts the ad-hoc signature the linker leaves on
+          # arm64 binaries, so nested code can pass verification and still come
+          # back Invalid from notarization. Check the authority instead.
+          while IFS= read -r nested; do
+            codesign --verify --strict "$nested"
+            codesign -dvv "$nested" 2>&1 | grep -q '^Authority=Developer ID Application' || {
+              echo "not signed with Developer ID: $nested" >&2
+              exit 1
+            }
+          done < <(find "$APP_PATH/Contents/MacOS" "$APP_PATH/Contents/Frameworks" -type f)
 
       - name: Notarize and staple
         env:
@@ -126,12 +142,25 @@ jobs:
 
           ditto -c -k --keepParent "$APP_PATH" "$ARTIFACT_PATH"
 
-          xcrun notarytool submit "$ARTIFACT_PATH" \
+          # `submit --wait` exits 0 on a rejected submission, so the status has
+          # to be read back. Without the notary log a rejection surfaces as an
+          # opaque stapler error several lines later.
+          submission="$(xcrun notarytool submit "$ARTIFACT_PATH" \
             --key "$notarization_key_path" \
             --key-id "$APPLE_NOTARIZATION_KEY_ID" \
             --issuer "$APPLE_NOTARIZATION_ISSUER" \
             --wait \
-            --timeout 30m
+            --timeout 30m \
+            --output-format json)"
+          echo "$submission"
+
+          if [[ "$(jq -r .status <<<"$submission")" != "Accepted" ]]; then
+            xcrun notarytool log "$(jq -r .id <<<"$submission")" \
+              --key "$notarization_key_path" \
+              --key-id "$APPLE_NOTARIZATION_KEY_ID" \
+              --issuer "$APPLE_NOTARIZATION_ISSUER"
+            exit 1
+          fi
 
           # The ticket staples to the .app, never to the zip that carried it
           # to Apple, so the bundle has to be repackaged afterwards. A release

--- a/src/ax.zig
+++ b/src/ax.zig
@@ -32,6 +32,9 @@ pub const AxStrings = struct {
     zoom_button_attr: c.CFStringRef,
     fullscreen_button_attr: c.CFStringRef,
     focused_attr: c.CFStringRef,
+    children_attr: c.CFStringRef,
+    tabs_attr: c.CFStringRef,
+    tab_group_role: c.CFStringRef,
 };
 
 var g_strings: ?AxStrings = null;
@@ -70,6 +73,9 @@ pub fn strings() ?*const AxStrings {
         "AXZoomButton",
         "AXFullScreenButton",
         "AXFocused",
+        "AXChildren",
+        "AXTabs",
+        "AXTabGroup",
     };
     var refs: [names.len]c.CFStringRef = undefined;
 
@@ -105,6 +111,9 @@ pub fn strings() ?*const AxStrings {
         .zoom_button_attr = refs[18],
         .fullscreen_button_attr = refs[19],
         .focused_attr = refs[20],
+        .children_attr = refs[21],
+        .tabs_attr = refs[22],
+        .tab_group_role = refs[23],
     };
     return &g_strings.?;
 }
@@ -112,6 +121,9 @@ pub fn strings() ?*const AxStrings {
 pub fn deinitStrings() void {
     if (g_strings) |s| {
         const refs = [_]c.CFStringRef{
+            s.tab_group_role,
+            s.tabs_attr,
+            s.children_attr,
             s.focused_attr,
             s.fullscreen_button_attr,
             s.zoom_button_attr,
@@ -296,6 +308,56 @@ pub fn focusedWindowIfMatches(pid: i32, target_wid: u32) ?c.AXUIElementRef {
         return null;
     }
     return focused_ref;
+}
+
+/// Number of tabs in a window's native tab bar, or 0 when it has none.
+///
+/// AppKit puts an `AXTabGroup` titled "tab bar" among a window's AX children,
+/// with one tab element per tab, and only the *selected* tab's window carries
+/// it. This is the one authoritative signal that a window belongs to a native
+/// tab group. Nothing else exposes the relationship: WindowServer models none
+/// (`SLSWindowIteratorGetParentID` is zero for every window and
+/// `SLSCopyAssociatedWindows` returns only the window itself), CG's window
+/// dictionary has no tab key, and `AXWindows` omits background tabs entirely,
+/// so their ids are not reachable at all.
+///
+/// Costs an AXChildren copy plus a role read per child, so callers should ask
+/// once per detection pass rather than per decision.
+pub fn tabCount(pid: i32, wid: u32) usize {
+    std.debug.assert(pid > 0);
+    std.debug.assert(wid > 0);
+
+    const ax = strings() orelse return 0;
+    const win = retainWindow(pid, wid) orelse return 0;
+    defer c.CFRelease(@ptrCast(win));
+
+    var children: c.CFArrayRef = null;
+    if (c.AXUIElementCopyAttributeValue(win, ax.children_attr, @ptrCast(&children)) != c.kAXErrorSuccess) return 0;
+    const children_ref = children orelse return 0;
+    defer c.CFRelease(@ptrCast(children_ref));
+
+    const count = c.CFArrayGetCount(children_ref);
+    var i: c.CFIndex = 0;
+    while (i < count) : (i += 1) {
+        const child_any = c.CFArrayGetValueAtIndex(children_ref, i) orelse continue;
+        const child: c.AXUIElementRef = @ptrCast(child_any);
+
+        var role: c.CFTypeRef = null;
+        if (c.AXUIElementCopyAttributeValue(child, ax.role_attr, &role) != c.kAXErrorSuccess) continue;
+        const role_ref = role orelse continue;
+        defer c.CFRelease(role_ref);
+        if (c.CFEqual(role_ref, @ptrCast(ax.tab_group_role)) == 0) continue;
+
+        var tabs: c.CFArrayRef = null;
+        if (c.AXUIElementCopyAttributeValue(child, ax.tabs_attr, @ptrCast(&tabs)) != c.kAXErrorSuccess) return 0;
+        const tabs_ref = tabs orelse return 0;
+        defer c.CFRelease(@ptrCast(tabs_ref));
+
+        const tab_total = c.CFArrayGetCount(tabs_ref);
+        return if (tab_total > 0) @intCast(tab_total) else 0;
+    }
+
+    return 0;
 }
 
 /// Query whether AXEnhancedUserInterface is currently enabled on an app element.

--- a/src/main.zig
+++ b/src/main.zig
@@ -4270,50 +4270,102 @@ fn discoverWindows() void {
     }
 }
 
-/// Find a managed on-screen sibling of the same PID occupying the same frame.
+/// Snapshot of the window ids CG reports on screen, excluding desktop elements
+/// and fully transparent windows.
 ///
-/// Used to guard tab inference against standalone window creation races
-/// (an on-screen sibling at the same frame means the candidate is a
-/// standalone window) and to locate the active tab when adopting an
-/// off-screen background tab into a group.
-fn findOnScreenMatchingManagedSibling(
-    pid: i32,
-    exclude_wid: u32,
-    target_frame: window_mod.Window.Frame,
-    sky: skylight.SkyLight,
-    conn: c_int,
-) ?u32 {
-    var store_it = g_store.windows.iterator();
-    while (store_it.next()) |entry| {
-        const candidate_wid = entry.key_ptr.*;
-        const candidate = entry.value_ptr.*;
-        if (candidate_wid == exclude_wid) continue;
-        if (candidate.pid != pid) continue;
-        if (!isVisibleOnScreen(candidate_wid)) continue;
+/// One copy answers for every window in a detection pass; asking per window
+/// costs a full list copy each time.
+const OnScreenWindows = struct {
+    wids: [512]u32 = undefined,
+    count: usize = 0,
 
-        var rect: skylight.CGRect = undefined;
-        if (sky.getWindowBounds(conn, candidate_wid, &rect) != 0) continue;
+    fn snapshot() OnScreenWindows {
+        var self: OnScreenWindows = .{};
 
-        const candidate_frame = window_mod.Window.Frame{
-            .x = rect.origin.x,
-            .y = rect.origin.y,
-            .width = rect.size.width,
-            .height = rect.size.height,
-        };
-        const matches = tabgroup.TabGroupManager.framesMatch(candidate_frame, target_frame);
-        log.debug("tab-match-guard: candidate wid={d} frame=({d:.0},{d:.0},{d:.0},{d:.0}) match={}", .{
-            candidate_wid,
-            candidate_frame.x,
-            candidate_frame.y,
-            candidate_frame.width,
-            candidate_frame.height,
-            matches,
-        });
+        const options: cg_extra.CGWindowListOption =
+            cg_extra.kCGWindowListOptionOnScreenOnly | cg_extra.kCGWindowListExcludeDesktopElements;
+        const list = cg_extra.CGWindowListCopyWindowInfo(options, cg_extra.kCGNullWindowID) orelse return self;
+        defer c.CFRelease(@ptrCast(list));
 
-        if (matches) return candidate_wid;
+        const total = c.CFArrayGetCount(list);
+        std.debug.assert(total >= 0);
+        var i: c.CFIndex = 0;
+        while (i < total and self.count < self.wids.len) : (i += 1) {
+            const info_any = c.CFArrayGetValueAtIndex(list, i) orelse continue;
+            const info: c.CFDictionaryRef = @ptrCast(info_any);
+            const wid_ref_any = c.CFDictionaryGetValue(info, cg_extra.kCGWindowNumber) orelse continue;
+            const wid_ref: c.CFNumberRef = @ptrCast(wid_ref_any);
+
+            var wid: u32 = 0;
+            if (c.CFNumberGetValue(wid_ref, c.kCFNumberSInt32Type, &wid) == 0) continue;
+            if (!cgWindowInfoVisible(info)) continue;
+
+            self.wids[self.count] = wid;
+            self.count += 1;
+        }
+
+        return self;
     }
 
-    return null;
+    fn contains(self: *const OnScreenWindows, wid: u32) bool {
+        return std.mem.findScalar(u32, self.wids[0..self.count], wid) != null;
+    }
+};
+
+/// Snapshot the managed windows of `pid` that tabgroup.detect reasons about.
+///
+/// Every OS query the heuristics need happens here, so the decisions themselves
+/// stay pure. `owns_workspace_slot` is the inverse of suppression: a group's
+/// leader holds the slot, its other members exist only in the store.
+fn tabCandidates(
+    pid: i32,
+    on_screen: *const OnScreenWindows,
+    out: []tabgroup.detect.Candidate,
+) usize {
+    std.debug.assert(pid > 0);
+
+    var count: usize = 0;
+    var it = g_store.windows.valueIterator();
+    while (it.next()) |win| {
+        if (count == out.len) break;
+        if (win.pid != pid) continue;
+
+        const on_visible_workspace = workspaceVisibleOnDisplay(win.workspace_id, win.display_id);
+        out[count] = .{
+            .wid = win.wid,
+            .pid = win.pid,
+            .live_frame = liveWindowFrame(win.wid),
+            .is_visible_on_screen = on_visible_workspace and on_screen.contains(win.wid),
+            .owns_workspace_slot = !g_tab_groups.isSuppressed(win.wid),
+        };
+        count += 1;
+    }
+    return count;
+}
+
+/// Snapshot the windows an application exposes in its AX window list.
+fn appWindowSnapshot(
+    pid: i32,
+    on_screen: *const OnScreenWindows,
+    out: []tabgroup.detect.AppWindow,
+) usize {
+    std.debug.assert(pid > 0);
+
+    var ax_wids: [128]u32 = undefined;
+    const ax_count = bw_get_app_window_ids(pid, &ax_wids);
+
+    var count: usize = 0;
+    for (ax_wids[0..ax_count]) |ax_wid| {
+        if (count == out.len) break;
+        out[count] = .{
+            .wid = ax_wid,
+            .live_frame = liveWindowFrame(ax_wid),
+            .is_on_screen = on_screen.contains(ax_wid),
+            .is_managed = g_store.get(ax_wid) != null,
+        };
+        count += 1;
+    }
+    return count;
 }
 
 fn addNewWindowManagedWithAssignment(pid: i32, wid: u32, workspace_id: u8, assigned_display_id: u32) bool {
@@ -4462,14 +4514,10 @@ fn addNewWindow(pid: i32, wid: u32) void {
     }
 }
 
-/// Add unmanaged same-PID AX windows that share the group's frame and are
-/// off-screen to the group as background tabs.
+/// Add the app's other background tabs at the group's frame as members.
 ///
-/// The guards matter: an unmanaged window that is visible on-screen or at
-/// different bounds is a standalone window racing through the role-pending
-/// or deferred pipelines, not a tab. Swallowing it as a group member would
-/// leave it permanently untiled (members are not in the layout) while other
-/// windows tile over its position.
+/// Members hold no workspace or layout slot, so they are stored and nothing
+/// else. Which windows qualify is tabgroup.detect's call.
 fn discoverBackgroundTabs(
     pid: i32,
     group_id: tabgroup.GroupId,
@@ -4482,189 +4530,110 @@ fn discoverBackgroundTabs(
     std.debug.assert(group_id != 0);
     std.debug.assert(workspace_id > 0 and workspace_id <= workspace_mod.max_workspaces);
 
-    const sky = g_sky orelse return;
-    const conn = sky.mainConnectionID();
+    const on_screen = OnScreenWindows.snapshot();
+    var app_windows: [128]tabgroup.detect.AppWindow = undefined;
+    const app_count = appWindowSnapshot(pid, &on_screen, &app_windows);
 
-    var ax_wids: [128]u32 = undefined;
-    const ax_count = bw_get_app_window_ids(pid, &ax_wids);
-    log.debug("discoverBackgroundTabs: AX found {d} windows for pid={d}", .{ ax_count, pid });
+    var members: [128]u32 = undefined;
+    const member_count = tabgroup.detect.additionalMembers(group_frame, app_windows[0..app_count], &members);
 
-    for (ax_wids[0..ax_count]) |ax_wid| {
-        // Managed windows (including the group's leader and active tab,
-        // which are stored before discovery runs) are never re-swallowed.
-        if (g_store.get(ax_wid) != null) continue;
-
-        var rect: skylight.CGRect = undefined;
-        if (sky.getWindowBounds(conn, ax_wid, &rect) != 0) {
-            log.debug("discoverBackgroundTabs: SkyLight.getWindowBounds failed for ax_wid={d}", .{ax_wid});
-            continue;
-        }
-        const f = window_mod.Window.Frame{
-            .x = rect.origin.x,
-            .y = rect.origin.y,
-            .width = rect.size.width,
-            .height = rect.size.height,
-        };
-
-        const frame_matches = tabgroup.TabGroupManager.framesMatch(f, group_frame);
-        const on_screen = bw_is_window_on_screen(ax_wid);
-        log.debug("discoverBackgroundTabs: ax_wid={d} frame=({d:.0},{d:.0},{d:.0},{d:.0}) match={} on_screen={}", .{
-            ax_wid, f.x, f.y, f.width, f.height, frame_matches, on_screen,
-        });
-        if (!frame_matches) continue;
-        if (on_screen) continue;
-
-        g_tab_groups.addMember(group_id, ax_wid) catch continue;
-        // The wid may still sit in the role-pending or deferred pipelines;
-        // it is accounted for as a tab member now, so promotion must not
-        // race against the group.
-        untrackPendingRoleWindow(ax_wid);
-        untrackDeferredWindowCandidate(ax_wid);
+    for (members[0..member_count]) |member_wid| {
+        g_tab_groups.addMember(group_id, member_wid) catch continue;
+        // The wid may still sit in the role-pending or deferred pipelines; it is
+        // accounted for as a member now, so promotion must not race the group.
+        untrackPendingRoleWindow(member_wid);
+        untrackDeferredWindowCandidate(member_wid);
         g_store.put(.{
-            .wid = ax_wid,
+            .wid = member_wid,
             .pid = pid,
             .title = null,
-            .frame = f,
+            .frame = group_frame,
             .is_minimized = false,
             .mode = mode,
             .workspace_id = workspace_id,
             .display_id = display_id,
         }) catch continue;
+        log.debug("tab member adopted wid={d} into group {d}", .{ member_wid, group_id });
     }
 }
 
-/// When a new on-screen window appears, check if an existing managed window
-/// from the same PID just went off-screen. If so, the new window is a tab
-/// that replaced the old one — form a tab group instead of tiling independently.
-/// Returns true if a tab group was formed (caller should NOT tile the window).
+/// Check whether a window that just appeared — created, or focused while
+/// unknown — is a native tab of an already-managed window, and if so hand it
+/// the group's slot. Returns true when a group absorbed it, meaning the caller
+/// must not manage it as its own window.
+///
+/// Gathers the OS facts, asks tabgroup.detect to decide, applies the outcome.
 fn tryFormTabGroupOnCreate(pid: i32, new_wid: u32) bool {
-    const sky = g_sky orelse return false;
-    const conn = sky.mainConnectionID();
-
-    // Get bounds of the new window
-    var new_rect: skylight.CGRect = undefined;
-    if (sky.getWindowBounds(conn, new_wid, &new_rect) != 0) return false;
-
-    const new_frame = window_mod.Window.Frame{
-        .x = new_rect.origin.x,
-        .y = new_rect.origin.y,
-        .width = new_rect.size.width,
-        .height = new_rect.size.height,
-    };
-    log.debug("tryFormTabGroup: new wid={d} bounds=({d:.0},{d:.0},{d:.0},{d:.0})", .{
+    const new_frame = liveWindowFrame(new_wid) orelse return false;
+    log.debug("tab detect: new wid={d} bounds=({d:.0},{d:.0},{d:.0},{d:.0})", .{
         new_wid, new_frame.x, new_frame.y, new_frame.width, new_frame.height,
     });
 
-    if (findOnScreenMatchingManagedSibling(pid, new_wid, new_frame, sky, conn) != null) {
-        log.debug("tryFormTabGroup: on-screen sibling matches new wid={d}, treating as standalone", .{new_wid});
-        return false;
-    }
+    const on_screen = OnScreenWindows.snapshot();
+    var candidates: [128]tabgroup.detect.Candidate = undefined;
+    const count = tabCandidates(pid, &on_screen, &candidates);
 
-    // Collect stale windows for deferred cleanup — can't call removeWindow
-    // while iterating workspace window lists (swapRemove invalidates indices).
+    // Collected before any removal: removeWindow mutates the workspace window
+    // lists that the snapshot describes.
     var stale_wids: [64]u32 = undefined;
-    var stale_count: usize = 0;
-    var formed = false;
+    const stale_count = tabgroup.detect.staleCandidates(pid, candidates[0..count], &stale_wids);
 
-    // Scan all workspaces for a same-PID window that is now off-screen
-    outer: for (&g_workspaces.workspaces) |*ws| {
-        for (ws.windows.items) |existing_wid| {
-            const existing = g_store.get(existing_wid) orelse continue;
-            if (existing.pid != pid) continue;
+    const formed = switch (tabgroup.detect.classifyNewWindow(pid, new_wid, new_frame, candidates[0..count])) {
+        .standalone => blk: {
+            log.debug("tab detect: wid={d} is standalone", .{new_wid});
+            break :blk false;
+        },
+        .tab_of => |sibling_wid| joinTabGroup(pid, sibling_wid, new_wid, new_frame),
+    };
 
-            const still_on_screen = isVisibleOnScreen(existing_wid);
-            log.debug("tryFormTabGroup: existing wid={d} on_screen={} frame=({d:.0},{d:.0},{d:.0},{d:.0})", .{
-                existing_wid,         still_on_screen,
-                existing.frame.x,     existing.frame.y,
-                existing.frame.width, existing.frame.height,
-            });
-
-            if (still_on_screen) continue;
-
-            // Verify the window still exists in CG. A destroyed window
-            // (e.g. a splash screen, closed dialog) fails the SkyLight
-            // lookup — mark for removal so ghost windows don't persist.
-            var existing_rect: skylight.CGRect = undefined;
-            if (sky.getWindowBounds(conn, existing_wid, &existing_rect) != 0) {
-                log.debug("tryFormTabGroup: existing wid={d} destroyed (SkyLight lookup failed), queuing removal", .{existing_wid});
-                if (stale_count < stale_wids.len) {
-                    stale_wids[stale_count] = existing_wid;
-                    stale_count += 1;
-                }
-                continue;
-            }
-
-            const existing_sky_frame = window_mod.Window.Frame{
-                .x = existing_rect.origin.x,
-                .y = existing_rect.origin.y,
-                .width = existing_rect.size.width,
-                .height = existing_rect.size.height,
-            };
-            log.debug("tryFormTabGroup: existing wid={d} SkyLight bounds=({d:.0},{d:.0},{d:.0},{d:.0})", .{
-                existing_wid,
-                existing_sky_frame.x,
-                existing_sky_frame.y,
-                existing_sky_frame.width,
-                existing_sky_frame.height,
-            });
-
-            // Native tab members share the same frame. If bounds diverge
-            // this is a different transition (splash→main, popup, etc.).
-            if (!tabgroup.TabGroupManager.framesMatch(new_frame, existing_sky_frame)) {
-                log.debug("tryFormTabGroup: bounds mismatch with wid={d}, not a tab", .{existing_wid});
-                continue;
-            }
-
-            // Form tab group: existing_wid is the leader (already in layout),
-            // new_wid is a member stored but NOT in the layout tree.
-            const group_id = if (g_tab_groups.groupOf(existing_wid)) |g|
-                g.id
-            else
-                g_tab_groups.createGroup(pid, existing_wid, existing.frame) catch break :outer;
-
-            g_tab_groups.addMember(group_id, new_wid) catch break :outer;
-            g_tab_groups.setActive(new_wid);
-
-            // Store the new window (suppressed — not in workspace/layout).
-            // Members inherit the leader's mode: a member that claims to be
-            // tiled under a floating leader gets inserted into the BSP tree
-            // the moment it inherits the group's workspace slot.
-            g_store.put(.{
-                .wid = new_wid,
-                .pid = pid,
-                .title = null,
-                .frame = new_frame,
-                .is_minimized = false,
-                .mode = existing.mode,
-                .workspace_id = ws.id,
-                .display_id = existing.display_id,
-            }) catch break :outer;
-
-            // Also discover any other background tabs
-            discoverBackgroundTabs(pid, group_id, new_frame, ws.id, existing.display_id, existing.mode);
-
-            ws.recordFocus(existing_wid); // leader stays
-            log.info("tryFormTabGroup: formed group leader={d} active={d} members={d}", .{
-                existing_wid,
-                new_wid,
-                if (g_tab_groups.groupOf(existing_wid)) |g| g.members.items.len else 1,
-            });
-            formed = true;
-            break :outer;
-        }
-    }
-
-    // Remove stale windows whose backing CG window no longer exists.
-    // Deferred to here because removeWindow mutates workspace window lists.
     for (stale_wids[0..stale_count]) |stale_wid| {
-        log.info("tryFormTabGroup: removing stale window wid={d}", .{stale_wid});
+        log.info("tab detect: removing stale window wid={d}", .{stale_wid});
         removeWindow(stale_wid);
     }
 
-    if (!formed) {
-        log.debug("tryFormTabGroup: no off-screen sibling found, proceeding as standalone", .{});
-    }
     return formed;
+}
+
+/// Add `new_wid` to `sibling_wid`'s tab group as the active tab.
+///
+/// The sibling keeps the group's workspace and layout slot; the new window is
+/// stored but suppressed, so nothing tiles, parks or dims it directly. Members
+/// inherit the leader's mode — a member claiming to be tiled under a floating
+/// leader would be inserted into the BSP tree the moment it inherited the slot.
+fn joinTabGroup(pid: i32, sibling_wid: u32, new_wid: u32, new_frame: window_mod.Window.Frame) bool {
+    const sibling = g_store.get(sibling_wid) orelse return false;
+    const ws = g_workspaces.get(sibling.workspace_id) orelse return false;
+
+    const group_id = if (g_tab_groups.groupOf(sibling_wid)) |g|
+        g.id
+    else
+        g_tab_groups.createGroup(pid, sibling_wid, sibling.frame) catch return false;
+
+    g_tab_groups.addMember(group_id, new_wid) catch return false;
+    g_tab_groups.setActive(new_wid);
+
+    g_store.put(.{
+        .wid = new_wid,
+        .pid = pid,
+        .title = null,
+        .frame = new_frame,
+        .is_minimized = false,
+        .mode = sibling.mode,
+        .workspace_id = sibling.workspace_id,
+        .display_id = sibling.display_id,
+    }) catch return false;
+
+    discoverBackgroundTabs(pid, group_id, new_frame, sibling.workspace_id, sibling.display_id, sibling.mode);
+
+    const leader = g_tab_groups.resolveLeader(sibling_wid);
+    ws.recordFocus(leader);
+    log.info("tab group formed pid={d} leader={d} active={d} members={d}", .{
+        pid,
+        leader,
+        new_wid,
+        if (g_tab_groups.groupOf(leader)) |g| g.members.items.len else 1,
+    });
+    return true;
 }
 
 fn removeWindow(wid: u32) void {
@@ -4736,15 +4705,13 @@ fn reconcileGroupActiveAfterRemoval(group_id: tabgroup.GroupId, pid: i32) void {
     std.debug.assert(group_id != 0);
     std.debug.assert(pid > 0);
 
+    const g = g_tab_groups.groups.getPtr(group_id) orelse return;
+
     const focused_wid = bw_ax_get_focused_window(pid);
-    if (focused_wid == 0) return;
+    const app_focused: ?u32 = if (focused_wid == 0) null else focused_wid;
+    const active = tabgroup.detect.activeAfterRemoval(app_focused, g.members.items) orelse return;
 
-    // Only accept the focused window when it belongs to the same group;
-    // a same-process standalone window must not be recorded as a tab.
-    const g = g_tab_groups.groupOf(focused_wid) orelse return;
-    if (g.id != group_id) return;
-
-    g_tab_groups.setActive(focused_wid);
+    g_tab_groups.setActive(active);
 }
 
 /// Hand a removed tab-group leader's workspace and layout slot to the new
@@ -4954,30 +4921,32 @@ fn cleanupOffscreenManagedWindows() bool {
 /// listed) and an on-screen managed sibling occupies the same frame (the
 /// active tab).
 fn adoptOffscreenWindowAsTab(win: window_mod.Window) bool {
-    const sky = g_sky orelse return false;
-    const conn = sky.mainConnectionID();
+    const frame = liveWindowFrame(win.wid);
 
-    var rect: skylight.CGRect = undefined;
-    if (sky.getWindowBounds(conn, win.wid, &rect) != 0) return false;
-    const frame = window_mod.Window.Frame{
-        .x = rect.origin.x,
-        .y = rect.origin.y,
-        .width = rect.size.width,
-        .height = rect.size.height,
+    const on_screen = OnScreenWindows.snapshot();
+    var app_windows: [128]tabgroup.detect.AppWindow = undefined;
+    const app_count = appWindowSnapshot(win.pid, &on_screen, &app_windows);
+    const listed_in_app = blk: {
+        for (app_windows[0..app_count]) |app_window| {
+            if (app_window.wid == win.wid) break :blk true;
+        }
+        break :blk false;
     };
 
-    var ax_wids: [128]u32 = undefined;
-    const ax_count = bw_get_app_window_ids(win.pid, &ax_wids);
-    var listed_in_ax = false;
-    for (ax_wids[0..ax_count]) |ax_wid| {
-        if (ax_wid == win.wid) {
-            listed_in_ax = true;
-            break;
-        }
-    }
-    if (!listed_in_ax) return false;
+    var candidates: [128]tabgroup.detect.Candidate = undefined;
+    const count = tabCandidates(win.pid, &on_screen, &candidates);
 
-    const sibling_wid = findOnScreenMatchingManagedSibling(win.pid, win.wid, frame, sky, conn) orelse return false;
+    const sibling_wid = switch (tabgroup.detect.classifyOffscreenManaged(
+        win.wid,
+        win.pid,
+        frame,
+        listed_in_app,
+        candidates[0..count],
+    )) {
+        .reap => return false,
+        .adopt_into => |sibling_wid| sibling_wid,
+    };
+
     const sibling = g_store.get(sibling_wid) orelse return false;
 
     const group_id = if (g_tab_groups.groupOf(sibling_wid)) |g|
@@ -4994,7 +4963,7 @@ fn adoptOffscreenWindowAsTab(win: window_mod.Window) bool {
     removeFromTiling(win.workspace_id, win.wid);
 
     var updated = win;
-    updated.frame = frame;
+    if (frame) |f| updated.frame = f;
     updated.workspace_id = sibling.workspace_id;
     updated.display_id = sibling.display_id;
     g_store.put(updated) catch {};
@@ -5565,122 +5534,17 @@ fn reconcileFocusedWindow(pid: i32, focused_wid: u32) void {
         return;
     }
 
-    // Case 3: focused wid is unknown — new tab becoming active, or new window.
-    log.debug("reconcile case 3: unknown wid={d}, checking bounds", .{focused_wid});
+    // Case 3: focused wid is unknown — a new tab becoming active, or a new
+    // window. Same decision as the creation path, so it runs the same code.
+    log.debug("reconcile case 3: unknown wid={d}", .{focused_wid});
 
-    const sky = g_sky orelse {
-        log.debug("reconcile: no SkyLight, falling back to addNewWindow", .{});
-        addNewWindow(pid, focused_wid);
-        retile();
-        return;
-    };
-    const conn = sky.mainConnectionID();
-
-    var focused_rect: skylight.CGRect = undefined;
-    if (sky.getWindowBounds(conn, focused_wid, &focused_rect) != 0) {
-        log.debug("reconcile: SkyLight.getWindowBounds failed for wid={d}", .{focused_wid});
-        addNewWindow(pid, focused_wid);
-        retile();
-        return;
-    }
-
-    const focused_frame = window_mod.Window.Frame{
-        .x = focused_rect.origin.x,
-        .y = focused_rect.origin.y,
-        .width = focused_rect.size.width,
-        .height = focused_rect.size.height,
-    };
-    log.debug("reconcile: focused bounds x={d:.0} y={d:.0} w={d:.0} h={d:.0}", .{
-        focused_frame.x, focused_frame.y, focused_frame.width, focused_frame.height,
-    });
-
-    const on_screen = isVisibleOnScreen(focused_wid);
-    log.debug("reconcile: on_screen={}", .{on_screen});
-
-    if (findOnScreenMatchingManagedSibling(pid, focused_wid, focused_frame, sky, conn) != null) {
-        log.debug("reconcile: on-screen sibling matches focused wid={d}, treating as new window", .{focused_wid});
-        addNewWindow(pid, focused_wid);
-        retile();
-        return;
-    }
-
-    // Look for a managed off-screen window (in any workspace) with the same
-    // PID and matching bounds. Matching an on-screen sibling is not a native
-    // tab transition signal because standalone windows can share the same
-    // tiled frame during focus/create event races.
-    var matching_wid: ?u32 = null;
-    var matching_ws_id: u8 = 0;
-    var matching_display_id: u32 = 0;
-    var matching_mode: window_mod.WindowMode = .tiled;
-    for (&g_workspaces.workspaces) |*ws| {
-        for (ws.windows.items) |wid| {
-            if (g_store.get(wid)) |win| {
-                if (win.pid == pid) {
-                    const candidate_on_screen = isVisibleOnScreen(wid);
-                    const matches = tabgroup.TabGroupManager.framesMatch(win.frame, focused_frame);
-                    log.debug("reconcile: candidate wid={d} ws={d} frame=({d:.0},{d:.0},{d:.0},{d:.0}) on_screen={} match={}", .{
-                        wid,
-                        ws.id,
-                        win.frame.x,
-                        win.frame.y,
-                        win.frame.width,
-                        win.frame.height,
-                        candidate_on_screen,
-                        matches,
-                    });
-                    if (matches and !candidate_on_screen) {
-                        matching_wid = wid;
-                        matching_ws_id = ws.id;
-                        matching_display_id = win.display_id;
-                        matching_mode = win.mode;
-                        break;
-                    }
-                }
-            }
-        }
-        if (matching_wid != null) break;
-    }
-
-    if (matching_wid) |managed_wid| {
-        log.debug("reconcile: matched managed_wid={d} ws={d} → forming tab group", .{
-            managed_wid, matching_ws_id,
-        });
-
-        const group_id = if (g_tab_groups.groupOf(managed_wid)) |g|
-            g.id
-        else
-            g_tab_groups.createGroup(pid, managed_wid, focused_frame) catch return;
-
-        g_tab_groups.addMember(group_id, focused_wid) catch return;
-        g_tab_groups.setActive(focused_wid);
-
-        g_store.put(.{
-            .wid = focused_wid,
-            .pid = pid,
-            .title = null,
-            .frame = focused_frame,
-            .is_minimized = false,
-            .mode = matching_mode,
-            .workspace_id = matching_ws_id,
-            .display_id = matching_display_id,
-        }) catch return;
-
-        // Discover additional background tabs
-        discoverBackgroundTabs(pid, group_id, focused_frame, matching_ws_id, matching_display_id, matching_mode);
-
-        const leader = g_tab_groups.resolveLeader(focused_wid);
+    if (tryFormTabGroupOnCreate(pid, focused_wid)) {
         _ = syncFocusStateForWindowId(focused_wid, .ax);
-
-        log.info("reconcile: tab group formed leader={d} active={d} members={d}", .{
-            leader,
-            focused_wid,
-            if (g_tab_groups.groupOf(leader)) |g| g.members.items.len else 1,
-        });
-    } else {
-        log.debug("reconcile: no matching managed window, treating as new window", .{});
-        addNewWindow(pid, focused_wid);
-        retile();
+        return;
     }
+
+    addNewWindow(pid, focused_wid);
+    retile();
 }
 
 /// Called on window_moved / window_resized — detects tab drag-out.
@@ -5690,22 +5554,11 @@ fn checkTabDragOut(_: i32, wid: u32) void {
     const g = g_tab_groups.groupOfMut(wid) orelse return;
     if (g.active_wid == wid) return; // only check suppressed members
 
-    const sky = g_sky orelse return;
-    const conn = sky.mainConnectionID();
-    var rect: skylight.CGRect = undefined;
-    if (sky.getWindowBounds(conn, wid, &rect) != 0) return;
-
-    const frame = window_mod.Window.Frame{
-        .x = rect.origin.x,
-        .y = rect.origin.y,
-        .width = rect.size.width,
-        .height = rect.size.height,
-    };
-
-    if (tabgroup.TabGroupManager.framesMatch(frame, g.canonical_frame)) return;
-
-    // Bounds diverged — this tab was dragged out to a standalone window
-    if (!isVisibleOnScreen(wid)) return; // still off-screen, not a drag-out
+    const frame = liveWindowFrame(wid) orelse return;
+    switch (tabgroup.detect.classifyMember(frame, g.canonical_frame, isVisibleOnScreen(wid))) {
+        .keep => return,
+        .promote_to_standalone => {},
+    }
 
     log.info("tab drag-out detected: wid={d} promoted to standalone", .{wid});
     const removal = g_tab_groups.removeMember(wid);

--- a/src/main.zig
+++ b/src/main.zig
@@ -2760,6 +2760,8 @@ fn bw_drain_events() void {
     g_event_drain_active = true;
     defer g_event_drain_active = false;
 
+    refreshTabGroupActiveTabs();
+
     while (g_ring.pop()) |ev| {
         handleEvent(&ev);
     }
@@ -4362,7 +4364,15 @@ fn appWindowSnapshot(
             .live_frame = liveWindowFrame(ax_wid),
             .is_on_screen = on_screen.contains(ax_wid),
             .is_managed = g_store.get(ax_wid) != null,
+            .tab_count = ax_mod.tabCount(pid, ax_wid),
         };
+        log.debug("tab facts pid={d} wid={d} tabs={d} on_screen={} managed={}", .{
+            pid,
+            ax_wid,
+            out[count].tab_count,
+            out[count].is_on_screen,
+            out[count].is_managed,
+        });
         count += 1;
     }
     return count;
@@ -4514,46 +4524,75 @@ fn addNewWindow(pid: i32, wid: u32) void {
     }
 }
 
-/// Add the app's other background tabs at the group's frame as members.
+/// Correct each tab group's recorded active tab against the window carrying its
+/// app's tab bar.
 ///
-/// Members hold no workspace or layout slot, so they are stored and nothing
-/// else. Which windows qualify is tabgroup.detect's call.
-fn discoverBackgroundTabs(
-    pid: i32,
-    group_id: tabgroup.GroupId,
-    group_frame: window_mod.Window.Frame,
-    workspace_id: u8,
-    display_id: u32,
-    mode: window_mod.WindowMode,
-) void {
-    std.debug.assert(pid > 0);
-    std.debug.assert(group_id != 0);
-    std.debug.assert(workspace_id > 0 and workspace_id <= workspace_mod.max_workspaces);
+/// macOS emits no notification of any kind when the user switches native tabs,
+/// so the recorded active tab is stale from that moment, and everything keyed
+/// off it — parking, restoring, retiling, focusing — would act on a window that
+/// is not on screen. The bar moves with the selection, so read it rather than
+/// track it.
+///
+/// The cheap gate is the point: a group whose recorded active tab is still on
+/// screen cannot have changed selection, so the AX work only happens on an actual
+/// switch. Only the active tab moves here; membership is decided elsewhere.
+fn refreshTabGroupActiveTabs() void {
+    if (g_tab_groups.groups.count() == 0) return;
 
     const on_screen = OnScreenWindows.snapshot();
-    var app_windows: [128]tabgroup.detect.AppWindow = undefined;
-    const app_count = appWindowSnapshot(pid, &on_screen, &app_windows);
 
-    var members: [128]u32 = undefined;
-    const member_count = tabgroup.detect.additionalMembers(group_frame, app_windows[0..app_count], &members);
+    const Move = struct { group_id: tabgroup.GroupId, selected: u32 };
+    var moves: [16]Move = undefined;
+    var move_count: usize = 0;
 
-    for (members[0..member_count]) |member_wid| {
-        g_tab_groups.addMember(group_id, member_wid) catch continue;
-        // The wid may still sit in the role-pending or deferred pipelines; it is
-        // accounted for as a member now, so promotion must not race the group.
-        untrackPendingRoleWindow(member_wid);
-        untrackDeferredWindowCandidate(member_wid);
-        g_store.put(.{
-            .wid = member_wid,
-            .pid = pid,
-            .title = null,
-            .frame = group_frame,
-            .is_minimized = false,
-            .mode = mode,
-            .workspace_id = workspace_id,
-            .display_id = display_id,
-        }) catch continue;
-        log.debug("tab member adopted wid={d} into group {d}", .{ member_wid, group_id });
+    var it = g_tab_groups.groups.valueIterator();
+    while (it.next()) |group| {
+        if (move_count == moves.len) break;
+
+        const leader = g_store.get(group.leader_wid) orelse continue;
+        // A parked group is off-screen on purpose and nothing acts on it until
+        // its workspace is shown again.
+        if (!workspaceVisibleOnDisplay(leader.workspace_id, leader.display_id)) continue;
+        if (on_screen.contains(group.active_wid)) continue;
+
+        var app_windows: [128]tabgroup.detect.AppWindow = undefined;
+        const app_count = appWindowSnapshot(group.pid, &on_screen, &app_windows);
+        const selected = tabgroup.detect.selectedTabWindow(
+            app_windows[0..app_count],
+            group.canonical_frame,
+        ) orelse continue;
+        if (selected == group.active_wid) continue;
+
+        moves[move_count] = .{ .group_id = group.id, .selected = selected };
+        move_count += 1;
+    }
+
+    // Applied after the walk: adopting a tab writes to the store and to the
+    // group's member list.
+    for (moves[0..move_count]) |move| {
+        const group = g_tab_groups.groups.getPtr(move.group_id) orelse continue;
+        const leader = g_store.get(group.leader_wid) orelse continue;
+
+        // The user can select a tab Bobrwm has never seen: background tabs are
+        // absent from AXWindows, so they are only discovered as they surface.
+        if (g_store.get(move.selected) == null) {
+            g_tab_groups.addMember(move.group_id, move.selected) catch continue;
+            g_store.put(.{
+                .wid = move.selected,
+                .pid = group.pid,
+                .title = null,
+                .frame = group.canonical_frame,
+                .is_minimized = false,
+                .mode = leader.mode,
+                .workspace_id = leader.workspace_id,
+                .display_id = leader.display_id,
+            }) catch continue;
+        }
+
+        log.debug("tab group {d} active tab {d} → {d} (tab bar)", .{
+            move.group_id, group.active_wid, move.selected,
+        });
+        g_tab_groups.setActive(move.selected);
     }
 }
 
@@ -4573,12 +4612,16 @@ fn tryFormTabGroupOnCreate(pid: i32, new_wid: u32) bool {
     var candidates: [128]tabgroup.detect.Candidate = undefined;
     const count = tabCandidates(pid, &on_screen, &candidates);
 
+    var app_windows: [128]tabgroup.detect.AppWindow = undefined;
+    const app_count = appWindowSnapshot(pid, &on_screen, &app_windows);
+    const has_tab_group = tabgroup.detect.appHasTabGroup(app_windows[0..app_count]);
+
     // Collected before any removal: removeWindow mutates the workspace window
     // lists that the snapshot describes.
     var stale_wids: [64]u32 = undefined;
     const stale_count = tabgroup.detect.staleCandidates(pid, candidates[0..count], &stale_wids);
 
-    const formed = switch (tabgroup.detect.classifyNewWindow(pid, new_wid, new_frame, candidates[0..count])) {
+    const formed = switch (tabgroup.detect.classifyNewWindow(pid, new_wid, new_frame, candidates[0..count], has_tab_group)) {
         .standalone => blk: {
             log.debug("tab detect: wid={d} is standalone", .{new_wid});
             break :blk false;
@@ -4622,8 +4665,6 @@ fn joinTabGroup(pid: i32, sibling_wid: u32, new_wid: u32, new_frame: window_mod.
         .workspace_id = sibling.workspace_id,
         .display_id = sibling.display_id,
     }) catch return false;
-
-    discoverBackgroundTabs(pid, group_id, new_frame, sibling.workspace_id, sibling.display_id, sibling.mode);
 
     const leader = g_tab_groups.resolveLeader(sibling_wid);
     ws.recordFocus(leader);
@@ -4855,9 +4896,9 @@ fn cleanupWorkspaceWindowsForPid(pid: i32) bool {
 /// Some Electron apps (Discord) close-to-background without emitting AX
 /// destroy/minimize notifications. This catches those ghost entries.
 ///
-/// Native background tabs are also off-screen, so windows that look like a
-/// missed tab-group inference are adopted into their sibling's group instead
-/// of being reaped (see adoptOffscreenWindowAsTab).
+/// Native background tabs are off-screen too, so each candidate goes through
+/// adoptOffscreenWindowAsTab, which keeps a window the app still lists, adopts a
+/// genuine background tab into its group, and reaps the rest.
 fn cleanupOffscreenManagedWindows() bool {
     var candidate_wids: [128]u32 = undefined;
     var candidate_count: usize = 0;
@@ -4895,14 +4936,15 @@ fn cleanupOffscreenManagedWindows() bool {
     for (candidate_wids[0..candidate_count]) |wid| {
         const win = g_store.get(wid) orelse continue;
 
-        if (adoptOffscreenWindowAsTab(win)) {
-            mutated = true;
-            continue;
+        switch (adoptOffscreenWindowAsTab(win)) {
+            .adopt => mutated = true,
+            .keep => {},
+            .reap => {
+                log.info("cleanup: removing wid={d} pid={d} reason=offscreen", .{ wid, win.pid });
+                removeWindow(wid);
+                mutated = true;
+            },
         }
-
-        log.info("cleanup: removing wid={d} pid={d} reason=offscreen", .{ wid, win.pid });
-        removeWindow(wid);
-        mutated = true;
     }
 
     return mutated;
@@ -4920,7 +4962,7 @@ fn cleanupOffscreenManagedWindows() bool {
 /// and destroyed ghosts drop out of AXWindows, native background tabs stay
 /// listed) and an on-screen managed sibling occupies the same frame (the
 /// active tab).
-fn adoptOffscreenWindowAsTab(win: window_mod.Window) bool {
+fn adoptOffscreenWindowAsTab(win: window_mod.Window) tabgroup.detect.OffscreenOutcomeKind {
     const frame = liveWindowFrame(win.wid);
 
     const on_screen = OnScreenWindows.snapshot();
@@ -4936,24 +4978,30 @@ fn adoptOffscreenWindowAsTab(win: window_mod.Window) bool {
     var candidates: [128]tabgroup.detect.Candidate = undefined;
     const count = tabCandidates(win.pid, &on_screen, &candidates);
 
+    const has_tab_group = tabgroup.detect.appHasTabGroup(app_windows[0..app_count]);
     const sibling_wid = switch (tabgroup.detect.classifyOffscreenManaged(
         win.wid,
         win.pid,
         frame,
         listed_in_app,
+        has_tab_group,
         candidates[0..count],
     )) {
-        .reap => return false,
+        .keep => {
+            log.debug("cleanup: keeping wid={d} pid={d}, the app still lists it", .{ win.wid, win.pid });
+            return .keep;
+        },
+        .reap => return .reap,
         .adopt_into => |sibling_wid| sibling_wid,
     };
 
-    const sibling = g_store.get(sibling_wid) orelse return false;
+    const sibling = g_store.get(sibling_wid) orelse return .reap;
 
     const group_id = if (g_tab_groups.groupOf(sibling_wid)) |g|
         g.id
     else
-        g_tab_groups.createGroup(win.pid, sibling_wid, sibling.frame) catch return false;
-    g_tab_groups.addMember(group_id, win.wid) catch return false;
+        g_tab_groups.createGroup(win.pid, sibling_wid, sibling.frame) catch return .reap;
+    g_tab_groups.addMember(group_id, win.wid) catch return .reap;
     g_tab_groups.setActive(sibling_wid);
 
     // Members live only in the store; drop the standalone workspace/layout slot.
@@ -4971,7 +5019,7 @@ fn adoptOffscreenWindowAsTab(win: window_mod.Window) bool {
     log.info("cleanup: adopted wid={d} as background tab, leader={d} pid={d}", .{
         win.wid, g_tab_groups.resolveLeader(sibling_wid), win.pid,
     });
-    return true;
+    return .adopt;
 }
 
 /// Updates `display_id` when a user-dragged window crosses monitors.
@@ -6196,6 +6244,10 @@ fn ipcDispatch(cmd: []const u8, client_fd: posix.socket_t) void {
         ipc.writeResponse(client_fd, "err: unknown or invalid command\n");
         return;
     };
+
+    // IPC does not pass through the event drain, but commands that move or focus
+    // windows need the same fresh view of which tab each group is showing.
+    refreshTabGroupActiveTabs();
 
     switch (command) {
         .retile => {

--- a/src/tabgroup.zig
+++ b/src/tabgroup.zig
@@ -1,8 +1,24 @@
+//! Tab groups: the window manager's model of a native-tabbed window.
+//!
+//! Two systems live under this name and are deliberately kept apart:
+//!
+//!   detect.zig  decides which window ids form one tabbed window and which is
+//!               on screen. Pure functions over a snapshot of OS facts.
+//!   this file    holds the resulting groups and the vocabulary the rest of the
+//!               window manager speaks: who owns the workspace slot (leader),
+//!               what is on screen (active), what must be hidden from tiling
+//!               and dimming (suppressed), and what a caller has to repair when
+//!               a member goes away.
+//!
+//! Nothing here infers anything. Nothing in detect.zig holds state.
+
 const std = @import("std");
 const WindowId = @import("window.zig").WindowId;
 const Frame = @import("window.zig").Window.Frame;
 
 const log = std.log.scoped(.tabgroup);
+
+pub const detect = @import("tabgroup/detect.zig");
 
 pub const GroupId = u32;
 
@@ -209,14 +225,9 @@ pub const TabGroupManager = struct {
         return g.leader_wid;
     }
 
-    /// Check if two frames match within ±2px tolerance.
-    pub fn framesMatch(a: Frame, b: Frame) bool {
-        const tol: f64 = 2.0;
-        return @abs(a.x - b.x) <= tol and
-            @abs(a.y - b.y) <= tol and
-            @abs(a.width - b.width) <= tol and
-            @abs(a.height - b.height) <= tol;
-    }
+    /// Frame comparison is a detection concern; kept here as the name the
+    /// window manager already calls.
+    pub const framesMatch = detect.framesMatch;
 };
 
 // Tests
@@ -284,4 +295,10 @@ test "removeMember returns none for an untracked window" {
         .none => {},
         else => return error.TestUnexpectedResult,
     }
+}
+
+// Pull in the detection module so its tests run under this test root
+// (`zig build test` compiles tabgroup.zig as the tabgroup-tests module).
+test {
+    _ = detect;
 }

--- a/src/tabgroup/detect.zig
+++ b/src/tabgroup/detect.zig
@@ -72,12 +72,17 @@ pub fn appHasTabGroup(app_windows: []const AppWindow) bool {
 ///
 /// Reading this beats remembering it. macOS emits no notification of any kind
 /// when the user switches native tabs, so a recorded active tab is stale from
-/// that moment, while the bar moves to whichever window is selected. Declines
-/// when two groups sit at the same frame, since nothing then says which is which.
+/// that moment, while the bar moves to whichever window is selected.
+///
+/// Only an on-screen window qualifies: the window showing a tab is on screen by
+/// definition, and without that a minimized window of another group at the same
+/// frame makes the answer look ambiguous when it is not. Still declines when two
+/// on-screen groups share a frame, since nothing then says which is which.
 pub fn selectedTabWindow(app_windows: []const AppWindow, group_frame: Frame) ?WindowId {
     var found: ?WindowId = null;
     for (app_windows) |app_window| {
         if (app_window.tab_count <= 1) continue;
+        if (!app_window.is_on_screen) continue;
 
         const live = app_window.live_frame orelse continue;
         if (!framesMatch(live, group_frame)) continue;
@@ -293,9 +298,18 @@ test "selectedTabWindow: the window carrying the bar at that frame" {
     try testing.expectEqual(@as(?WindowId, 3), selectedTabWindow(&app_windows, tiled_right));
 }
 
-test "selectedTabWindow: declines when two groups share a frame" {
+test "selectedTabWindow: declines when two on-screen groups share a frame" {
     const app_windows = [_]AppWindow{ appWin(2, tiled_left, 3), appWin(4, tiled_left, 2) };
     try testing.expectEqual(@as(?WindowId, null), selectedTabWindow(&app_windows, tiled_left));
+}
+
+test "selectedTabWindow: an off-screen group at the same frame is not a rival" {
+    // A minimized window of another group reports the same frame; it cannot be
+    // the window showing a tab, so it must not make the answer ambiguous.
+    var minimized = appWin(4, tiled_left, 2);
+    minimized.is_on_screen = false;
+    const app_windows = [_]AppWindow{ appWin(2, tiled_left, 3), minimized };
+    try testing.expectEqual(@as(?WindowId, 2), selectedTabWindow(&app_windows, tiled_left));
 }
 
 test "classifyNewWindow: a window replacing an off-screen sibling is its tab" {

--- a/src/tabgroup/detect.zig
+++ b/src/tabgroup/detect.zig
@@ -47,7 +47,46 @@ pub const AppWindow = struct {
     /// Raw CG on-screen state, without the workspace-visibility adjustment.
     is_on_screen: bool,
     is_managed: bool,
+    /// Tabs in this window's own tab bar, from AXTabGroup. Zero when it has
+    /// none: a standalone window, or a background tab, since only the selected
+    /// tab of a group carries the bar.
+    tab_count: usize,
 };
+
+/// Whether the app has any native tab group at all — some window of it carries a
+/// tab bar with more than one tab.
+///
+/// This is the gate every tab decision hangs off. Without a bar somewhere in the
+/// app, no window of it can be a background tab, so inference must not run: two
+/// same-app windows at one frame are then just two windows, which is exactly
+/// what a floating app whose windows stack looks like.
+pub fn appHasTabGroup(app_windows: []const AppWindow) bool {
+    for (app_windows) |app_window| {
+        if (app_window.tab_count > 1) return true;
+    }
+    return false;
+}
+
+/// The window showing a tab group's selected tab: the one carrying the bar at
+/// `group_frame`.
+///
+/// Reading this beats remembering it. macOS emits no notification of any kind
+/// when the user switches native tabs, so a recorded active tab is stale from
+/// that moment, while the bar moves to whichever window is selected. Declines
+/// when two groups sit at the same frame, since nothing then says which is which.
+pub fn selectedTabWindow(app_windows: []const AppWindow, group_frame: Frame) ?WindowId {
+    var found: ?WindowId = null;
+    for (app_windows) |app_window| {
+        if (app_window.tab_count <= 1) continue;
+
+        const live = app_window.live_frame orelse continue;
+        if (!framesMatch(live, group_frame)) continue;
+
+        if (found != null) return null;
+        found = app_window.wid;
+    }
+    return found;
+}
 
 // ── New or newly-focused window ──────────────────────────────────────────────
 
@@ -66,19 +105,19 @@ pub const NewWindowOutcome = union(enum) {
 /// owns a workspace slot, and WindowServer still puts it at the new window's
 /// frame, since native tabs of one group share their window's frame.
 ///
-/// An *on-screen* sibling at the same frame vetoes the whole decision: that is
-/// what two standalone windows racing through creation look like. It is also
-/// what a floating app whose windows stack looks like, which is why this
-/// returns `standalone` for a real tab in that configuration — see the tests.
+/// `app_has_tab_group` gates the whole decision: with no tab bar anywhere in the
+/// app there is nothing for the window to be a tab of, however well the frames
+/// line up. That is what keeps a floating app whose windows stack at identical
+/// frames from reading as a tab transition.
 pub fn classifyNewWindow(
     pid: i32,
     new_wid: WindowId,
     new_frame: Frame,
     candidates: []const Candidate,
+    app_has_tab_group: bool,
 ) NewWindowOutcome {
+    if (!app_has_tab_group) return .standalone;
     if (new_frame.width <= 1 or new_frame.height <= 1) return .standalone;
-
-    if (findVisibleSiblingAtFrame(pid, new_wid, new_frame, candidates) != null) return .standalone;
 
     for (candidates) |candidate| {
         if (candidate.wid == new_wid) continue;
@@ -134,38 +173,17 @@ pub fn staleCandidates(pid: i32, candidates: []const Candidate, out: []WindowId)
     return count;
 }
 
-// ── Additional members of a known group ──────────────────────────────────────
-
-/// Unmanaged windows of an app that sit off-screen at a group's frame, i.e.
-/// further background tabs of that group. Returns the number written to `out`.
-///
-/// The guards matter: an unmanaged window that is on screen, or at different
-/// bounds, is a standalone window racing through the creation pipeline rather
-/// than a tab. Swallowing one as a member would leave it permanently untiled.
-pub fn additionalMembers(
-    group_frame: Frame,
-    app_windows: []const AppWindow,
-    out: []WindowId,
-) usize {
-    var count: usize = 0;
-    for (app_windows) |app_window| {
-        if (count == out.len) break;
-        if (app_window.is_managed) continue;
-        if (app_window.is_on_screen) continue;
-
-        const live = app_window.live_frame orelse continue;
-        if (!framesMatch(live, group_frame)) continue;
-
-        out[count] = app_window.wid;
-        count += 1;
-    }
-    return count;
-}
-
 // ── Off-screen managed window found by cleanup ───────────────────────────────
 
+/// The action an off-screen managed window needs, without the payload — what a
+/// caller reports back once it has applied the decision.
+pub const OffscreenOutcomeKind = enum { keep, reap, adopt };
+
 pub const OffscreenOutcome = union(enum) {
-    /// No sibling claims it; the caller should remove it.
+    /// Leave it alone: the app still exposes it, so it is a live window that is
+    /// merely not on screen, not a ghost and not a tab.
+    keep,
+    /// Nothing claims it; the caller should remove it.
     reap,
     /// It is a background tab of the named window's group.
     adopt_into: WindowId,
@@ -175,19 +193,27 @@ pub const OffscreenOutcome = union(enum) {
 /// visible workspace.
 ///
 /// Tab inference happens at creation and focus time; when that is missed — event
-/// races, mid-animation bounds, events dropped during a workspace transition —
-/// a background tab remains managed as a standalone window that is now
-/// off-screen, and reaping it would lose the tab. `listed_in_app` is whether the
-/// app still exposes the window in its AX window list.
+/// races, mid-animation bounds, events dropped during a workspace transition — a
+/// background tab remains managed as a standalone window that is now off-screen,
+/// and reaping it would lose the tab.
+///
+/// `listed_in_app` is whether the app still exposes the window in `AXWindows`.
+/// Being listed rules a window *out* as a background tab: macOS drops background
+/// tabs from that list, which is measurable by arithmetic — a five-tab group
+/// contributes exactly one listed window, and the other four tabs' titles appear
+/// nowhere in it.
 pub fn classifyOffscreenManaged(
     wid: WindowId,
     pid: i32,
     live_frame: ?Frame,
     listed_in_app: bool,
+    app_has_tab_group: bool,
     candidates: []const Candidate,
 ) OffscreenOutcome {
+    if (listed_in_app) return .keep;
+
     const frame = live_frame orelse return .reap;
-    if (!listed_in_app) return .reap;
+    if (!app_has_tab_group) return .reap;
 
     const sibling = findVisibleSiblingAtFrame(pid, wid, frame, candidates) orelse return .reap;
     return .{ .adopt_into = sibling };
@@ -250,9 +276,63 @@ fn managed(wid: WindowId, frame: Frame, visible: bool) Candidate {
     };
 }
 
+/// An app window carrying a tab bar of `tabs` tabs.
+fn appWin(wid: WindowId, frame: ?Frame, tabs: usize) AppWindow {
+    return .{ .wid = wid, .live_frame = frame, .is_on_screen = true, .is_managed = true, .tab_count = tabs };
+}
+
+test "appHasTabGroup: only a bar with more than one tab counts" {
+    try testing.expect(!appHasTabGroup(&[_]AppWindow{}));
+    try testing.expect(!appHasTabGroup(&[_]AppWindow{ appWin(1, tiled_left, 0), appWin(2, tiled_left, 1) }));
+    try testing.expect(appHasTabGroup(&[_]AppWindow{ appWin(1, tiled_left, 0), appWin(2, tiled_left, 2) }));
+}
+
+test "selectedTabWindow: the window carrying the bar at that frame" {
+    const app_windows = [_]AppWindow{ appWin(1, tiled_left, 0), appWin(2, tiled_left, 3), appWin(3, tiled_right, 2) };
+    try testing.expectEqual(@as(?WindowId, 2), selectedTabWindow(&app_windows, tiled_left));
+    try testing.expectEqual(@as(?WindowId, 3), selectedTabWindow(&app_windows, tiled_right));
+}
+
+test "selectedTabWindow: declines when two groups share a frame" {
+    const app_windows = [_]AppWindow{ appWin(2, tiled_left, 3), appWin(4, tiled_left, 2) };
+    try testing.expectEqual(@as(?WindowId, null), selectedTabWindow(&app_windows, tiled_left));
+}
+
 test "classifyNewWindow: a window replacing an off-screen sibling is its tab" {
     const candidates = [_]Candidate{managed(1, tiled_left, false)};
-    const outcome = classifyNewWindow(100, 2, tiled_left, &candidates);
+    const outcome = classifyNewWindow(100, 2, tiled_left, &candidates, true);
+    try testing.expectEqual(@as(WindowId, 1), outcome.tab_of);
+}
+
+test "classifyNewWindow: no tab bar in the app means no tab, however the frames line up" {
+    // The fix: this is the stacked floating case. Window 1 sits off-screen at
+    // exactly the new window's frame, which used to be enough to group them.
+    const candidates = [_]Candidate{managed(1, tiled_left, false)};
+    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, tiled_left, &candidates, false));
+}
+
+test "classifyNewWindow: a stacked floating app is never grouped" {
+    // Several same-pid windows at pixel-identical frames, no tab bar anywhere:
+    // a Ghostty-style sessionizer. Previously the on-screen sibling veto had to
+    // catch this, and it also blocked real tabs; now the gate decides.
+    const candidates = [_]Candidate{
+        managed(1, tiled_left, false),
+        managed(3, tiled_left, true),
+        managed(4, tiled_left, true),
+    };
+    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, tiled_left, &candidates, false));
+}
+
+test "classifyNewWindow: a real tab is found even with siblings stacked at its frame" {
+    // The case the old veto got wrong: the app does have a tab bar, window 1
+    // really did drop out of view at this frame, and unrelated on-screen windows
+    // 3 and 4 share it. The tab must still be recognised.
+    const candidates = [_]Candidate{
+        managed(1, tiled_left, false),
+        managed(3, tiled_left, true),
+        managed(4, tiled_left, true),
+    };
+    const outcome = classifyNewWindow(100, 2, tiled_left, &candidates, true);
     try testing.expectEqual(@as(WindowId, 1), outcome.tab_of);
 }
 
@@ -260,46 +340,25 @@ test "classifyNewWindow: a different app at the same frame is not a tab" {
     var other = managed(1, tiled_left, false);
     other.pid = 999;
     const candidates = [_]Candidate{other};
-    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, tiled_left, &candidates));
+    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, tiled_left, &candidates, true));
 }
 
 test "classifyNewWindow: a sibling at another frame is not a tab" {
     const candidates = [_]Candidate{managed(1, tiled_right, false)};
-    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, tiled_left, &candidates));
+    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, tiled_left, &candidates, true));
 }
 
 test "classifyNewWindow: unsettled bounds never match" {
-    const candidates = [_]Candidate{managed(1, .{ .x = 0, .y = 0, .width = 0, .height = 0 }, false)};
     const degenerate: Frame = .{ .x = 0, .y = 0, .width = 0, .height = 0 };
-    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, degenerate, &candidates));
+    const candidates = [_]Candidate{managed(1, degenerate, false)};
+    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, degenerate, &candidates, true));
 }
 
 test "classifyNewWindow: a suppressed member does not own a slot to join" {
     var member = managed(1, tiled_left, false);
     member.owns_workspace_slot = false;
     const candidates = [_]Candidate{member};
-    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, tiled_left, &candidates));
-}
-
-test "classifyNewWindow: an on-screen sibling at the same frame vetoes inference" {
-    // Two standalone windows racing through creation at one tiled frame.
-    const candidates = [_]Candidate{ managed(1, tiled_left, false), managed(3, tiled_left, true) };
-    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, tiled_left, &candidates));
-}
-
-test "classifyNewWindow: KNOWN BAD - a stacked floating app defeats inference" {
-    // A floating app whose windows stack (a Ghostty-style sessionizer) has
-    // several same-pid windows at pixel-identical frames. Window 1 really did
-    // become a background tab of the new window, but unrelated window 3 sits
-    // on screen at the same frame, so the veto fires and the tab is managed as
-    // a standalone window. Pinned so a future fix has to change this on
-    // purpose.
-    const candidates = [_]Candidate{
-        managed(1, tiled_left, false),
-        managed(3, tiled_left, true),
-        managed(4, tiled_left, true),
-    };
-    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, tiled_left, &candidates));
+    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, tiled_left, &candidates, true));
 }
 
 test "staleCandidates: collects same-app slots WindowServer forgot" {
@@ -316,39 +375,33 @@ test "staleCandidates: collects same-app slots WindowServer forgot" {
     try testing.expectEqual(@as(WindowId, 1), out[0]);
 }
 
-test "additionalMembers: only unmanaged off-screen windows at the group frame" {
-    const app_windows = [_]AppWindow{
-        .{ .wid = 1, .live_frame = tiled_left, .is_on_screen = false, .is_managed = true }, // managed
-        .{ .wid = 2, .live_frame = tiled_left, .is_on_screen = true, .is_managed = false }, // on screen
-        .{ .wid = 3, .live_frame = tiled_right, .is_on_screen = false, .is_managed = false }, // other frame
-        .{ .wid = 4, .live_frame = null, .is_on_screen = false, .is_managed = false }, // gone
-        .{ .wid = 5, .live_frame = tiled_left, .is_on_screen = false, .is_managed = false }, // tab
-    };
-    var out: [8]WindowId = undefined;
-    const count = additionalMembers(tiled_left, &app_windows, &out);
-    try testing.expectEqual(@as(usize, 1), count);
-    try testing.expectEqual(@as(WindowId, 5), out[0]);
-}
-
-test "classifyOffscreenManaged: adopts when the app still lists it and a sibling matches" {
+test "classifyOffscreenManaged: adopts a window the app has dropped from AXWindows" {
     const candidates = [_]Candidate{managed(3, tiled_left, true)};
-    const outcome = classifyOffscreenManaged(1, 100, tiled_left, true, &candidates);
+    const outcome = classifyOffscreenManaged(1, 100, tiled_left, false, true, &candidates);
     try testing.expectEqual(@as(WindowId, 3), outcome.adopt_into);
 }
 
-test "classifyOffscreenManaged: reaps a window the app no longer lists" {
+test "classifyOffscreenManaged: a still-listed window is left alone" {
+    // Being listed rules it out as a background tab, and reaping a live window
+    // the app still exposes would lose it.
     const candidates = [_]Candidate{managed(3, tiled_left, true)};
-    try testing.expectEqual(OffscreenOutcome.reap, classifyOffscreenManaged(1, 100, tiled_left, false, &candidates));
+    try testing.expectEqual(OffscreenOutcome.keep, classifyOffscreenManaged(1, 100, tiled_left, true, true, &candidates));
+}
+
+test "classifyOffscreenManaged: reaps when the app has no tab group" {
+    // An Electron window that closed to background: nothing for it to be a tab of.
+    const candidates = [_]Candidate{managed(3, tiled_left, true)};
+    try testing.expectEqual(OffscreenOutcome.reap, classifyOffscreenManaged(1, 100, tiled_left, false, false, &candidates));
 }
 
 test "classifyOffscreenManaged: reaps when no sibling occupies the frame" {
     const candidates = [_]Candidate{managed(3, tiled_right, true)};
-    try testing.expectEqual(OffscreenOutcome.reap, classifyOffscreenManaged(1, 100, tiled_left, true, &candidates));
+    try testing.expectEqual(OffscreenOutcome.reap, classifyOffscreenManaged(1, 100, tiled_left, false, true, &candidates));
 }
 
 test "classifyOffscreenManaged: reaps a window WindowServer forgot" {
     const candidates = [_]Candidate{managed(3, tiled_left, true)};
-    try testing.expectEqual(OffscreenOutcome.reap, classifyOffscreenManaged(1, 100, null, true, &candidates));
+    try testing.expectEqual(OffscreenOutcome.reap, classifyOffscreenManaged(1, 100, null, false, true, &candidates));
 }
 
 test "classifyMember: diverged bounds while on screen is a drag-out" {

--- a/src/tabgroup/detect.zig
+++ b/src/tabgroup/detect.zig
@@ -1,0 +1,366 @@
+//! Native-tab detection: which window ids belong to one tabbed window, and
+//! which of them is on screen.
+//!
+//! Every decision here is a pure function over a snapshot of OS facts. Nothing
+//! in this file touches AX, WindowServer, or Bobrwm's state, so the heuristics
+//! can be exercised in tests without a live desktop — which matters because
+//! they are heuristics, and the interesting cases (a floating app whose windows
+//! stack at identical frames) are the ones that are painful to reproduce by
+//! hand. The window manager gathers the snapshot, calls in here, and applies
+//! the outcome.
+
+const std = @import("std");
+const window_mod = @import("../window.zig");
+
+const WindowId = window_mod.WindowId;
+const Frame = window_mod.Window.Frame;
+
+/// Native tabs of one group report the same frame, but CG and AX round
+/// independently across process boundaries, so allow a couple of pixels.
+pub const frame_tolerance: f64 = 2.0;
+
+pub fn framesMatch(a: Frame, b: Frame) bool {
+    return a.approxEqual(b, frame_tolerance);
+}
+
+/// A managed window as detection sees it: identity plus the OS facts the
+/// heuristics read.
+pub const Candidate = struct {
+    wid: WindowId,
+    pid: i32,
+    /// WindowServer bounds. Null when WindowServer no longer knows the window,
+    /// which is how a destroyed one looks.
+    live_frame: ?Frame,
+    /// Workspace-aware: false for a window parked on a hidden workspace, which
+    /// is why raw CG on-screen state is not enough on its own.
+    is_visible_on_screen: bool,
+    /// Whether this window appears in a workspace window list. Suppressed tab
+    /// members live only in the store, and must not be mistaken for a window
+    /// that owns a slot.
+    owns_workspace_slot: bool,
+};
+
+/// One window of an application, as reported by its AX window list.
+pub const AppWindow = struct {
+    wid: WindowId,
+    live_frame: ?Frame,
+    /// Raw CG on-screen state, without the workspace-visibility adjustment.
+    is_on_screen: bool,
+    is_managed: bool,
+};
+
+// ── New or newly-focused window ──────────────────────────────────────────────
+
+pub const NewWindowOutcome = union(enum) {
+    /// Nothing looks like a tab sibling; manage it as its own window.
+    standalone,
+    /// The named managed window just moved into the background at this
+    /// window's frame, so the new window is a tab of that window's group.
+    tab_of: WindowId,
+};
+
+/// Decide whether a window that just appeared — created, or focused while
+/// unknown — is a native tab of an already-managed window.
+///
+/// A candidate qualifies when it belongs to the same app, is no longer visible,
+/// owns a workspace slot, and WindowServer still puts it at the new window's
+/// frame, since native tabs of one group share their window's frame.
+///
+/// An *on-screen* sibling at the same frame vetoes the whole decision: that is
+/// what two standalone windows racing through creation look like. It is also
+/// what a floating app whose windows stack looks like, which is why this
+/// returns `standalone` for a real tab in that configuration — see the tests.
+pub fn classifyNewWindow(
+    pid: i32,
+    new_wid: WindowId,
+    new_frame: Frame,
+    candidates: []const Candidate,
+) NewWindowOutcome {
+    if (new_frame.width <= 1 or new_frame.height <= 1) return .standalone;
+
+    if (findVisibleSiblingAtFrame(pid, new_wid, new_frame, candidates) != null) return .standalone;
+
+    for (candidates) |candidate| {
+        if (candidate.wid == new_wid) continue;
+        if (candidate.pid != pid) continue;
+        if (!candidate.owns_workspace_slot) continue;
+        if (candidate.is_visible_on_screen) continue;
+
+        const live = candidate.live_frame orelse continue;
+        if (!framesMatch(new_frame, live)) continue;
+
+        return .{ .tab_of = candidate.wid };
+    }
+
+    return .standalone;
+}
+
+/// A managed window of `pid` that is on screen at `frame`. Used both to veto
+/// tab inference and to locate the active tab an off-screen window sits behind.
+pub fn findVisibleSiblingAtFrame(
+    pid: i32,
+    exclude_wid: WindowId,
+    frame: Frame,
+    candidates: []const Candidate,
+) ?WindowId {
+    for (candidates) |candidate| {
+        if (candidate.wid == exclude_wid) continue;
+        if (candidate.pid != pid) continue;
+        if (!candidate.is_visible_on_screen) continue;
+
+        const live = candidate.live_frame orelse continue;
+        if (!framesMatch(live, frame)) continue;
+
+        return candidate.wid;
+    }
+    return null;
+}
+
+/// Managed windows of `pid` that WindowServer no longer knows: ghost store
+/// entries the caller should reap. Collected separately from the decision above
+/// so that stays a pure choice. Returns the number written to `out`.
+pub fn staleCandidates(pid: i32, candidates: []const Candidate, out: []WindowId) usize {
+    var count: usize = 0;
+    for (candidates) |candidate| {
+        if (count == out.len) break;
+        if (candidate.pid != pid) continue;
+        if (!candidate.owns_workspace_slot) continue;
+        if (candidate.is_visible_on_screen) continue;
+        if (candidate.live_frame != null) continue;
+
+        out[count] = candidate.wid;
+        count += 1;
+    }
+    return count;
+}
+
+// ── Additional members of a known group ──────────────────────────────────────
+
+/// Unmanaged windows of an app that sit off-screen at a group's frame, i.e.
+/// further background tabs of that group. Returns the number written to `out`.
+///
+/// The guards matter: an unmanaged window that is on screen, or at different
+/// bounds, is a standalone window racing through the creation pipeline rather
+/// than a tab. Swallowing one as a member would leave it permanently untiled.
+pub fn additionalMembers(
+    group_frame: Frame,
+    app_windows: []const AppWindow,
+    out: []WindowId,
+) usize {
+    var count: usize = 0;
+    for (app_windows) |app_window| {
+        if (count == out.len) break;
+        if (app_window.is_managed) continue;
+        if (app_window.is_on_screen) continue;
+
+        const live = app_window.live_frame orelse continue;
+        if (!framesMatch(live, group_frame)) continue;
+
+        out[count] = app_window.wid;
+        count += 1;
+    }
+    return count;
+}
+
+// ── Off-screen managed window found by cleanup ───────────────────────────────
+
+pub const OffscreenOutcome = union(enum) {
+    /// No sibling claims it; the caller should remove it.
+    reap,
+    /// It is a background tab of the named window's group.
+    adopt_into: WindowId,
+};
+
+/// Decide what to do with a managed window that cleanup found off-screen on a
+/// visible workspace.
+///
+/// Tab inference happens at creation and focus time; when that is missed — event
+/// races, mid-animation bounds, events dropped during a workspace transition —
+/// a background tab remains managed as a standalone window that is now
+/// off-screen, and reaping it would lose the tab. `listed_in_app` is whether the
+/// app still exposes the window in its AX window list.
+pub fn classifyOffscreenManaged(
+    wid: WindowId,
+    pid: i32,
+    live_frame: ?Frame,
+    listed_in_app: bool,
+    candidates: []const Candidate,
+) OffscreenOutcome {
+    const frame = live_frame orelse return .reap;
+    if (!listed_in_app) return .reap;
+
+    const sibling = findVisibleSiblingAtFrame(pid, wid, frame, candidates) orelse return .reap;
+    return .{ .adopt_into = sibling };
+}
+
+// ── Existing member drifting away from its group ─────────────────────────────
+
+pub const MemberOutcome = enum {
+    /// Still a tab of the group.
+    keep,
+    /// Dragged out of the tab bar into a window of its own.
+    promote_to_standalone,
+};
+
+/// Decide whether a suppressed member has been torn out of its tab group.
+/// Bounds that diverge from the group's frame while the window is on screen are
+/// the drag-out signal; a member that is still off-screen has simply not been
+/// placed.
+pub fn classifyMember(
+    live_frame: ?Frame,
+    canonical_frame: Frame,
+    is_visible_on_screen: bool,
+) MemberOutcome {
+    const frame = live_frame orelse return .keep;
+    if (framesMatch(frame, canonical_frame)) return .keep;
+    if (!is_visible_on_screen) return .keep;
+    return .promote_to_standalone;
+}
+
+// ── Active tab after a member is removed ─────────────────────────────────────
+
+/// The member that should become active after one is removed.
+///
+/// Removal picks a surviving member arbitrarily, but macOS selects the adjacent
+/// tab, so prefer whatever the app itself reports as focused. Returns null when
+/// the app's focused window is not a member, leaving the caller's guess in
+/// place until the next focus notification corrects it.
+pub fn activeAfterRemoval(app_focused_wid: ?WindowId, members: []const WindowId) ?WindowId {
+    const focused = app_focused_wid orelse return null;
+    for (members) |member| {
+        if (member == focused) return focused;
+    }
+    return null;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+const tiled_left: Frame = .{ .x = 0, .y = 0, .width = 400, .height = 800 };
+const tiled_right: Frame = .{ .x = 400, .y = 0, .width = 400, .height = 800 };
+
+fn managed(wid: WindowId, frame: Frame, visible: bool) Candidate {
+    return .{
+        .wid = wid,
+        .pid = 100,
+        .live_frame = frame,
+        .is_visible_on_screen = visible,
+        .owns_workspace_slot = true,
+    };
+}
+
+test "classifyNewWindow: a window replacing an off-screen sibling is its tab" {
+    const candidates = [_]Candidate{managed(1, tiled_left, false)};
+    const outcome = classifyNewWindow(100, 2, tiled_left, &candidates);
+    try testing.expectEqual(@as(WindowId, 1), outcome.tab_of);
+}
+
+test "classifyNewWindow: a different app at the same frame is not a tab" {
+    var other = managed(1, tiled_left, false);
+    other.pid = 999;
+    const candidates = [_]Candidate{other};
+    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, tiled_left, &candidates));
+}
+
+test "classifyNewWindow: a sibling at another frame is not a tab" {
+    const candidates = [_]Candidate{managed(1, tiled_right, false)};
+    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, tiled_left, &candidates));
+}
+
+test "classifyNewWindow: unsettled bounds never match" {
+    const candidates = [_]Candidate{managed(1, .{ .x = 0, .y = 0, .width = 0, .height = 0 }, false)};
+    const degenerate: Frame = .{ .x = 0, .y = 0, .width = 0, .height = 0 };
+    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, degenerate, &candidates));
+}
+
+test "classifyNewWindow: a suppressed member does not own a slot to join" {
+    var member = managed(1, tiled_left, false);
+    member.owns_workspace_slot = false;
+    const candidates = [_]Candidate{member};
+    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, tiled_left, &candidates));
+}
+
+test "classifyNewWindow: an on-screen sibling at the same frame vetoes inference" {
+    // Two standalone windows racing through creation at one tiled frame.
+    const candidates = [_]Candidate{ managed(1, tiled_left, false), managed(3, tiled_left, true) };
+    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, tiled_left, &candidates));
+}
+
+test "classifyNewWindow: KNOWN BAD - a stacked floating app defeats inference" {
+    // A floating app whose windows stack (a Ghostty-style sessionizer) has
+    // several same-pid windows at pixel-identical frames. Window 1 really did
+    // become a background tab of the new window, but unrelated window 3 sits
+    // on screen at the same frame, so the veto fires and the tab is managed as
+    // a standalone window. Pinned so a future fix has to change this on
+    // purpose.
+    const candidates = [_]Candidate{
+        managed(1, tiled_left, false),
+        managed(3, tiled_left, true),
+        managed(4, tiled_left, true),
+    };
+    try testing.expectEqual(NewWindowOutcome.standalone, classifyNewWindow(100, 2, tiled_left, &candidates));
+}
+
+test "staleCandidates: collects same-app slots WindowServer forgot" {
+    var gone = managed(1, tiled_left, false);
+    gone.live_frame = null;
+    var other_app = managed(2, tiled_left, false);
+    other_app.pid = 999;
+    other_app.live_frame = null;
+
+    const candidates = [_]Candidate{ gone, other_app, managed(3, tiled_left, false) };
+    var out: [4]WindowId = undefined;
+    const count = staleCandidates(100, &candidates, &out);
+    try testing.expectEqual(@as(usize, 1), count);
+    try testing.expectEqual(@as(WindowId, 1), out[0]);
+}
+
+test "additionalMembers: only unmanaged off-screen windows at the group frame" {
+    const app_windows = [_]AppWindow{
+        .{ .wid = 1, .live_frame = tiled_left, .is_on_screen = false, .is_managed = true }, // managed
+        .{ .wid = 2, .live_frame = tiled_left, .is_on_screen = true, .is_managed = false }, // on screen
+        .{ .wid = 3, .live_frame = tiled_right, .is_on_screen = false, .is_managed = false }, // other frame
+        .{ .wid = 4, .live_frame = null, .is_on_screen = false, .is_managed = false }, // gone
+        .{ .wid = 5, .live_frame = tiled_left, .is_on_screen = false, .is_managed = false }, // tab
+    };
+    var out: [8]WindowId = undefined;
+    const count = additionalMembers(tiled_left, &app_windows, &out);
+    try testing.expectEqual(@as(usize, 1), count);
+    try testing.expectEqual(@as(WindowId, 5), out[0]);
+}
+
+test "classifyOffscreenManaged: adopts when the app still lists it and a sibling matches" {
+    const candidates = [_]Candidate{managed(3, tiled_left, true)};
+    const outcome = classifyOffscreenManaged(1, 100, tiled_left, true, &candidates);
+    try testing.expectEqual(@as(WindowId, 3), outcome.adopt_into);
+}
+
+test "classifyOffscreenManaged: reaps a window the app no longer lists" {
+    const candidates = [_]Candidate{managed(3, tiled_left, true)};
+    try testing.expectEqual(OffscreenOutcome.reap, classifyOffscreenManaged(1, 100, tiled_left, false, &candidates));
+}
+
+test "classifyOffscreenManaged: reaps when no sibling occupies the frame" {
+    const candidates = [_]Candidate{managed(3, tiled_right, true)};
+    try testing.expectEqual(OffscreenOutcome.reap, classifyOffscreenManaged(1, 100, tiled_left, true, &candidates));
+}
+
+test "classifyOffscreenManaged: reaps a window WindowServer forgot" {
+    const candidates = [_]Candidate{managed(3, tiled_left, true)};
+    try testing.expectEqual(OffscreenOutcome.reap, classifyOffscreenManaged(1, 100, null, true, &candidates));
+}
+
+test "classifyMember: diverged bounds while on screen is a drag-out" {
+    try testing.expectEqual(MemberOutcome.promote_to_standalone, classifyMember(tiled_right, tiled_left, true));
+    try testing.expectEqual(MemberOutcome.keep, classifyMember(tiled_right, tiled_left, false));
+    try testing.expectEqual(MemberOutcome.keep, classifyMember(tiled_left, tiled_left, true));
+    try testing.expectEqual(MemberOutcome.keep, classifyMember(null, tiled_left, true));
+}
+
+test "activeAfterRemoval: prefers the app's focused window when it is a member" {
+    const members = [_]WindowId{ 1, 2, 3 };
+    try testing.expectEqual(@as(?WindowId, 2), activeAfterRemoval(2, &members));
+    try testing.expectEqual(@as(?WindowId, null), activeAfterRemoval(9, &members));
+    try testing.expectEqual(@as(?WindowId, null), activeAfterRemoval(null, &members));
+}


### PR DESCRIPTION
The original frame method doesn't work if you have several windows of the exact same size.