### PR TITLE
Harden window coordination and AX state

### DIFF
--- a/.agents/skills/bobrwm-state/SKILL.md
+++ b/.agents/skills/bobrwm-state/SKILL.md
@@ -10,7 +10,7 @@ bobrwm reconciles four state sources — AX, WindowServer/CG, SkyLight, and its 
 
 ## Querying the daemon (IPC)
 
-The daemon listens on `/tmp/bobrwm_<uid>.sock`. Any `bobrwm` binary acts as an IPC client (during development use `zig-out/bin/bobrwm`; the daemon may be running from there rather than PATH — check `ps ax | rg bobrwm`).
+The daemon listens on `/tmp/bobrwm_<uid>.sock`. Use `zig-out/Bobrwm.app/Contents/MacOS/bobrwm-cli` as the development IPC client; check `ps ax | rg '[b]obrwm'` to identify the running daemon.
 
 ```bash
 bobrwm query workspaces --json   # ALL workspaces with their windows, frames, focused_window, visible flag
@@ -45,7 +45,7 @@ Run it once for a baseline, reproduce the bug, then run it again — the delta t
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `bobrwm_bin` | string | PATH, then `<repo>/zig-out/bin/bobrwm` | IPC client binary |
+| `bobrwm_bin` | string | PATH, then `<repo>/zig-out/Bobrwm.app/Contents/MacOS/bobrwm-cli` | IPC client binary |
 | `frame_tolerance` | number | 2 | px slack before flagging frame drift |
 | `expect_dimming_overlays` | boolean | `false` | Require overlays even if none are visible; set when dimming is known enabled |
 | `output_file` | string | — | Save raw queries + snapshot JSON for offline diffing |
@@ -54,10 +54,7 @@ The raw snapshot includes `window_kind`, `owner_name`, and `cg_order` for every 
 
 ## Logs
 
-Where the daemon logs depends on how it was started:
-
-- **launchd service** (`bobrwm service install`): `/tmp/bobrwm_<user>.out.log` and `/tmp/bobrwm_<user>.err.log`
-- **manual / `zig build run`**: stdout/stderr of that terminal
+The daemon writes its log to `~/Library/Caches/bobrwm/bobrwm.log`. A manual foreground run may also expose output in its terminal.
 
 Log level is **compile-time**: a release binary has no `log.debug` output at all. To get the high-signal transition/cleanup/tab/AX-reconciliation logs, rebuild:
 
@@ -74,10 +71,10 @@ Restarting bobrwm resets workspace assignments and re-adopts windows — it dest
 
 ```bash
 bobrwm service restart        # if running as a launchd service
-# or kill the manual process and rerun zig-out/bin/bobrwm
+# or quit the manual process and rerun zig build run
 ```
 
-If the daemon is running from `zig-out/bin/bobrwm` via `zig build run`, rebuilding while it runs is fine; the new binary takes effect on next restart.
+If the daemon is running from the app bundle via `zig build run`, rebuilding while it runs is fine; the new binary takes effect on next restart.
 
 ## Debugging workflow
 

--- a/.agents/skills/bobrwm-state/toolbox/compare_state.nu
+++ b/.agents/skills/bobrwm-state/toolbox/compare_state.nu
@@ -14,7 +14,7 @@ def describe [] {
         inputSchema: {
             type: "object"
             properties: {
-                bobrwm_bin: { type: "string", description: "Path to the bobrwm binary (default: PATH, then <repo>/zig-out/bin/bobrwm)" }
+                bobrwm_bin: { type: "string", description: "Path to the bobrwm CLI (default: PATH, then <repo>/zig-out/Bobrwm.app/Contents/MacOS/bobrwm-cli)" }
                 frame_tolerance: { type: "number", description: "Max px difference between bobrwm frame and CG bounds before flagging drift (default: 2)" }
                 expect_dimming_overlays: { type: "boolean", description: "Require overlays for every inactive visible window, including when none are present (default: false; use when dimming is known enabled)" }
                 output_file: { type: "string", description: "Optional file path to save the raw snapshot + query JSON" }
@@ -33,9 +33,9 @@ def find-bobrwm [explicit] {
     let from_path = (which bobrwm | get -o 0 | get -o path)
     if $from_path != null { return $from_path }
     # Repo checkout: this skill lives at <repo>/.agents/skills/bobrwm-state
-    let repo_bin = ([(skill-dir), "..", "..", "..", "zig-out", "bin", "bobrwm"] | path join | path expand)
+    let repo_bin = ([(skill-dir), "..", "..", "..", "zig-out", "Bobrwm.app", "Contents", "MacOS", "bobrwm-cli"] | path join | path expand)
     if ($repo_bin | path exists) { return $repo_bin }
-    print "error: bobrwm binary not found on PATH or in zig-out/bin. Pass bobrwm_bin."
+    print "error: bobrwm CLI not found on PATH or in zig-out/Bobrwm.app/Contents/MacOS. Pass bobrwm_bin."
     exit 1
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ZIG_VERSION: 0.16.0
+
+jobs:
+  verify:
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: ${{ env.ZIG_VERSION }}
+
+      - name: Check formatting
+        run: zig fmt --check build.zig src packages
+
+      - name: Test
+        run: zig build test
+
+      - name: Build Debug
+        run: zig build
+
+      - name: Build ReleaseFast
+        run: zig build -Doptimize=ReleaseFast

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ concurrency:
 permissions:
   contents: write
 
+env:
+  ZIG_VERSION: 0.16.0
+
 jobs:
   build:
     runs-on: macos-15
@@ -23,7 +26,12 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Install Zig
-        run: brew install zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: ${{ env.ZIG_VERSION }}
+
+      - name: Test
+        run: zig build test
 
       - name: Configure artifact
         env:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ bobrwm query apps --json  # IPC: list observed apps as JSON
 bobrwm focus-workspace next # IPC: switch to next workspace without wrapping
 bobrwm focus-workspace prev # IPC: switch to previous workspace without wrapping
 bobrwm move-to-display 2  # IPC: move focused window to display slot 2
-bobrwm bsp insert-mode stack          # IPC: split | stack
 bobrwm bsp insert-point min_depth     # IPC: focused | first | last | min_depth
 bobrwm bsp ratio rel 0.05             # IPC: adjust focused parent split ratio
 bobrwm bsp ratio abs 0.6              # IPC: set focused parent split ratio
@@ -130,9 +129,9 @@ Config is loaded from (in order):
 If no config file is found, built-in defaults are used. See [`examples/config.zon`](examples/config.zon) for a full example.
 
 Press `Alt+Shift+R` (the default `reload_config` binding) to apply changes
-without restarting. If the file contains invalid ZON, bobrwm keeps the last
-valid configuration and shows a temporary error in its menu-bar item; parser
-details remain in the error log.
+without restarting. If the file contains invalid ZON or values outside the
+documented bounds, bobrwm keeps the last valid configuration and shows a
+temporary error in its menu-bar item; details remain in the error log.
 
 The same reload is available from the command line:
 
@@ -168,6 +167,7 @@ built-in defaults; use the same key + modifiers to override a default binding.
 | `focus_previous_workspace` | Switch to the previous workspace; if already at the first workspace, pass the key through | — |
 | `focus_next_workspace` | Switch to the next workspace; if already at the last workspace, pass the key through | — |
 | `move_to_workspace` | Move focused window to workspace N | workspace number |
+| `move_workspace_to_display` | Move the active workspace to display N | display number |
 | `focus_left` | Focus window to the left | — |
 | `focus_right` | Focus window to the right | — |
 | `focus_up` | Focus window above | — |
@@ -175,6 +175,12 @@ built-in defaults; use the same key + modifiers to override a default binding.
 | `toggle_split` | Toggle next split direction | — |
 | `toggle_fullscreen` | Toggle focused window fullscreen | — |
 | `toggle_float` | Toggle focused window floating | — |
+| `swap_left` | Swap the focused tiled window left | — |
+| `swap_right` | Swap the focused tiled window right | — |
+| `swap_up` | Swap the focused tiled window up | — |
+| `swap_down` | Swap the focused tiled window down | — |
+| `center_float` | Center the focused floating window | — |
+| `toggle_dimming` | Toggle inactive-window dimming | — |
 | `reload_config` | Reload the config file, keeping the current config if parsing fails | — |
 
 ### Gaps
@@ -194,6 +200,7 @@ Choose the tiling algorithm:
 
 ```zon
 .layout = .bsp, // .bsp | .monocle
+.bsp_split_ratio = 0.5, // finite value from 0.1 through 0.9
 ```
 
 ### Workspaces
@@ -211,7 +218,7 @@ By default, bobrwm creates 10 workspaces. To configure a smaller count, provide 
 },
 ```
 
-Workspace IDs are still 1-based, so the example above creates workspaces 1 through 4. Keybinds and app assignments should only reference workspaces in that range. The current maximum is 10 workspaces.
+Workspace IDs are still 1-based, so the example above creates workspaces 1 through 4. Keybinds and app assignments must reference workspaces in that range. The current maximum is 10 workspaces; invalid references reject the entire config.
 
 ### Workspace Assignments
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ built-in defaults; use the same key + modifiers to override a default binding.
 | `focus_previous_workspace` | Switch to the previous workspace; if already at the first workspace, pass the key through | — |
 | `focus_next_workspace` | Switch to the next workspace; if already at the last workspace, pass the key through | — |
 | `move_to_workspace` | Move focused window to workspace N | workspace number |
-| `move_workspace_to_display` | Move the active workspace to display N | display number |
+| `move_workspace_to_display` | Move the active workspace to display N, next, or previous | display number; `0` = next, `255` = previous |
 | `focus_left` | Focus window to the left | — |
 | `focus_right` | Focus window to the right | — |
 | `focus_up` | Focus window above | — |

--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ without `start_at_login` runs unsupervised.
 
 ### Logging
 
-The window manager writes to `/tmp/bobrwm_$(id -u).log` as well as stderr, so
+The window manager writes to `~/Library/Caches/bobrwm/bobrwm.log` as well as stderr, so
 logs are there however it was started — from Finder there is no terminal to
 read. The file is appended across restarts, which keeps the tail that explains
 a crash, and is truncated at startup once it passes 8 MiB.
 
 ```bash
-tail -f "/tmp/bobrwm_$(id -u).log"
+tail -f ~/Library/Caches/bobrwm/bobrwm.log
 ```
 
 Log level is compile-time configurable and applies to both binaries. Default

--- a/build.zig
+++ b/build.zig
@@ -412,6 +412,19 @@ pub fn build(b: *std.Build) !void {
 
     const run_queue_tests = b.addRunArtifact(queue_tests);
 
+    const geometry_test_mod = b.createModule(.{
+        .root_source_file = b.path("src/geometry.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const geometry_tests = b.addTest(.{
+        .name = "geometry-tests",
+        .root_module = geometry_test_mod,
+    });
+
+    const run_geometry_tests = b.addRunArtifact(geometry_tests);
+
     // tabgroup.zig and tiling.zig are pure Zig (window.zig types only),
     // so their test modules need no SDK or include wiring either.
     const tabgroup_test_mod = b.createModule(.{
@@ -528,6 +541,7 @@ pub fn build(b: *std.Build) !void {
     test_step.dependOn(&run_tests.step);
     test_step.dependOn(&run_ipc_tests.step);
     test_step.dependOn(&run_queue_tests.step);
+    test_step.dependOn(&run_geometry_tests.step);
     test_step.dependOn(&run_tabgroup_tests.step);
     test_step.dependOn(&run_tiling_tests.step);
     test_step.dependOn(&run_workspace_tests.step);

--- a/build.zig
+++ b/build.zig
@@ -399,6 +399,19 @@ pub fn build(b: *std.Build) !void {
 
     const run_ipc_tests = b.addRunArtifact(ipc_tests);
 
+    const queue_test_mod = b.createModule(.{
+        .root_source_file = b.path("src/spsc_queue.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const queue_tests = b.addTest(.{
+        .name = "spsc-queue-tests",
+        .root_module = queue_test_mod,
+    });
+
+    const run_queue_tests = b.addRunArtifact(queue_tests);
+
     // tabgroup.zig and tiling.zig are pure Zig (window.zig types only),
     // so their test modules need no SDK or include wiring either.
     const tabgroup_test_mod = b.createModule(.{
@@ -514,6 +527,7 @@ pub fn build(b: *std.Build) !void {
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_tests.step);
     test_step.dependOn(&run_ipc_tests.step);
+    test_step.dependOn(&run_queue_tests.step);
     test_step.dependOn(&run_tabgroup_tests.step);
     test_step.dependOn(&run_tiling_tests.step);
     test_step.dependOn(&run_workspace_tests.step);

--- a/build.zig
+++ b/build.zig
@@ -255,6 +255,12 @@ pub fn build(b: *std.Build) !void {
     swipe_mod.addImport("c", c_mod);
     swipe_mod.addImport("cg_extra", cg_extra_mod);
     swipe_mod.addImport("bobrwm_config", swipe_config_mod);
+    swipe_mod.addImport("runtime_paths", b.createModule(.{
+        .root_source_file = b.path("src/runtime_paths.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    }));
     swipe_mod.addAssemblyFile(b.path("packages/bobrwm-swipe/src/info_plist.s"));
     swipe_mod.linkFramework("ApplicationServices", .{});
     swipe_mod.linkFramework("CoreGraphics", .{});
@@ -484,6 +490,12 @@ pub fn build(b: *std.Build) !void {
     swipe_test_mod.addImport("c", c_mod);
     swipe_test_mod.addImport("cg_extra", cg_extra_mod);
     swipe_test_mod.addImport("bobrwm_config", swipe_config_mod);
+    swipe_test_mod.addImport("runtime_paths", b.createModule(.{
+        .root_source_file = b.path("src/runtime_paths.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    }));
     swipe_test_mod.linkFramework("ApplicationServices", .{});
     swipe_test_mod.linkFramework("CoreGraphics", .{});
     swipe_test_mod.linkFramework("AppKit", .{});

--- a/examples/config.zon
+++ b/examples/config.zon
@@ -19,7 +19,7 @@
     // .focused, .first, .last, .min_depth
     // .bsp_insert_point = .focused,
 
-    // Default ratio for newly-created BSP splits (clamped to 0.1..0.9).
+    // Default ratio for newly-created BSP splits (must be 0.1..0.9).
     // .bsp_split_ratio = 0.5,
 
     // Placement for newly tiled windows when splitting.

--- a/packages/bobrwm-swipe/src/main.zig
+++ b/packages/bobrwm-swipe/src/main.zig
@@ -9,7 +9,7 @@ const runtime_paths = @import("runtime_paths");
 
 const log = std.log.scoped(.bobrwm_swipe);
 
-const max_touches: usize = 16;
+const max_touches: usize = config_mod.max_swipe_fingers;
 const nsevent_type_gesture: c.CGEventType = 29;
 const touch_phase_ended: u32 = 1 << 3;
 const touch_phase_cancelled: u32 = 1 << 4;
@@ -168,7 +168,7 @@ fn parseCli(process_args: std.process.Args) Cli {
 
 fn validateSwipeConfig(config: config_mod.SwipeConfig) !RuntimeConfig {
     if (config.fingers == 0 or config.fingers > max_touches) return error.InvalidFingerCount;
-    if (config.distance_pct <= 0 or config.distance_pct > 1) return error.InvalidDistancePct;
+    if (!std.math.isFinite(config.distance_pct) or config.distance_pct <= 0 or config.distance_pct > 1) return error.InvalidDistancePct;
     return .{
         .fingers = config.fingers,
         .distance_pct = config.distance_pct,

--- a/packages/bobrwm-swipe/src/main.zig
+++ b/packages/bobrwm-swipe/src/main.zig
@@ -100,7 +100,8 @@ const GestureState = struct {
         if (@abs(avg_dx) <= @abs(avg_dy)) return null;
 
         self.fired = true;
-        return if (avg_dx < 0 and !runtime.reverse) .previous else .next;
+        const moves_previous = (avg_dx < 0) != runtime.reverse;
+        return if (moves_previous) .previous else .next;
     }
 };
 
@@ -414,23 +415,45 @@ test "validate swipe config" {
     try t.expectError(error.InvalidDistancePct, validateSwipeConfig(.{ .distance_pct = 1.1 }));
 }
 
-test "gesture frame fires once without wrapping policy" {
+test "gesture frame maps both directions with reverse policy" {
     const t = std.testing;
 
-    var state: GestureState = .{};
-    const runtime: RuntimeConfig = .{ .fingers = 3, .distance_pct = 0.08 };
     const start = [_]TouchSample{
         .{ .id = 1, .x = 0.5, .y = 0.5 },
         .{ .id = 2, .x = 0.6, .y = 0.5 },
         .{ .id = 3, .x = 0.7, .y = 0.5 },
     };
-    state.begin(&start);
-
-    const moved = [_]TouchSample{
+    const moved_left = [_]TouchSample{
         .{ .id = 1, .x = 0.4, .y = 0.51 },
         .{ .id = 2, .x = 0.5, .y = 0.51 },
         .{ .id = 3, .x = 0.6, .y = 0.51 },
     };
-    try t.expectEqual(Direction.previous, state.update(&moved, runtime).?);
-    try t.expectEqual(@as(?Direction, null), state.update(&moved, runtime));
+    const moved_right = [_]TouchSample{
+        .{ .id = 1, .x = 0.6, .y = 0.49 },
+        .{ .id = 2, .x = 0.7, .y = 0.49 },
+        .{ .id = 3, .x = 0.8, .y = 0.49 },
+    };
+
+    const cases = [_]struct {
+        moved: []const TouchSample,
+        reverse: bool,
+        expected: Direction,
+    }{
+        .{ .moved = &moved_left, .reverse = false, .expected = .previous },
+        .{ .moved = &moved_right, .reverse = false, .expected = .next },
+        .{ .moved = &moved_left, .reverse = true, .expected = .next },
+        .{ .moved = &moved_right, .reverse = true, .expected = .previous },
+    };
+
+    for (cases) |case| {
+        var state: GestureState = .{};
+        state.begin(&start);
+        const runtime: RuntimeConfig = .{
+            .fingers = 3,
+            .distance_pct = 0.08,
+            .reverse = case.reverse,
+        };
+        try t.expectEqual(case.expected, state.update(case.moved, runtime).?);
+        try t.expectEqual(@as(?Direction, null), state.update(case.moved, runtime));
+    }
 }

--- a/packages/bobrwm-swipe/src/main.zig
+++ b/packages/bobrwm-swipe/src/main.zig
@@ -5,6 +5,7 @@ const objc = @import("objc");
 const c = @import("c");
 const cg_extra = @import("cg_extra");
 const config_mod = @import("bobrwm_config");
+const runtime_paths = @import("runtime_paths");
 
 const log = std.log.scoped(.bobrwm_swipe);
 
@@ -295,7 +296,7 @@ fn findSample(samples: []const TouchSample, id: usize) ?TouchSample {
 
 fn sendIpcCommand(cmd: []const u8) IpcResult {
     var path_buf: [128]u8 = undefined;
-    const path = std.fmt.bufPrintSentinel(&path_buf, "/tmp/bobrwm_{d}.sock", .{std.c.getuid()}, 0) catch return .failed;
+    const path = runtime_paths.socketPathBuf(&path_buf) catch return .failed;
 
     const fd = std.c.socket(std.posix.AF.UNIX, std.posix.SOCK.STREAM, 0);
     if (fd < 0) return .failed;
@@ -306,8 +307,9 @@ fn sendIpcCommand(cmd: []const u8) IpcResult {
     };
 
     var addr: std.posix.sockaddr.un = .{ .path = undefined, .family = std.posix.AF.UNIX };
+    if (path.len >= addr.path.len) return .failed;
     @memcpy(addr.path[0..path.len], path[0..path.len]);
-    if (path.len < addr.path.len) addr.path[path.len] = 0;
+    addr.path[path.len] = 0;
 
     if (std.c.connect(fd, @ptrCast(&addr), @sizeOf(std.posix.sockaddr.un)) != 0) return .failed;
     if (!writeAll(fd, cmd)) return .failed;

--- a/src/ax_observer.zig
+++ b/src/ax_observer.zig
@@ -444,7 +444,10 @@ fn scheduleObserveRetry(pid: i32) void {
     if (observeRetryIndex(pid)) |existing| {
         g_observe_retry_entries[existing].attempts_remaining = observe_retry_attempts_max;
     } else {
-        if (g_observe_retry_count >= max_observed_apps) return;
+        if (g_observe_retry_count >= max_observed_apps) {
+            log.warn("AX observe retry queue exhausted pid={d} limit={d}", .{ pid, max_observed_apps });
+            return;
+        }
         g_observe_retry_entries[g_observe_retry_count] = .{
             .pid = pid,
             .attempts_remaining = observe_retry_attempts_max,
@@ -687,7 +690,10 @@ fn retryResolveWid(context: ?*anyopaque) callconv(.c) void {
 }
 
 fn scheduleWidResolutionRetry(observer: c.AXObserverRef, element: c.AXUIElementRef, pid: i32) void {
-    const ctx = acquireWidRetryCtx() orelse return;
+    const ctx = acquireWidRetryCtx() orelse {
+        log.warn("AX window-id retry pool exhausted pid={d} limit={d}", .{ pid, max_wid_retry_contexts });
+        return;
+    };
 
     const retained_observer = c.CFRetain(@ptrCast(observer)) orelse {
         releaseWidRetryCtx(ctx);

--- a/src/ax_observer.zig
+++ b/src/ax_observer.zig
@@ -156,21 +156,32 @@ fn deinitAxObserverStrings() void {
 
 // Background observer thread
 
+fn axThreadKeepalivePerform(context: ?*anyopaque) callconv(.c) void {
+    _ = context;
+}
+
 fn axThreadEntry(context: ?*anyopaque) callconv(.c) ?*anyopaque {
     _ = context;
-    g_ax_thread_runloop = c.CFRunLoopGetCurrent();
-    g_ax_thread_ready.store(true, .release);
+    const run_loop = c.CFRunLoopGetCurrent();
+    g_ax_thread_runloop = run_loop;
 
-    // CFRunLoopRun returns when CFRunLoopStop is called from the main thread
-    // during deinit.  The run loop needs at least one source to avoid
-    // returning immediately; we rely on AX observer sources being added
-    // shortly after init.  As a safety net, run in a timed mode so we can
-    // re-check even if no source is ever added.
-    while (true) {
-        const result = c.CFRunLoopRunInMode(c.kCFRunLoopDefaultMode, 60.0, 0);
-        // kCFRunLoopRunStopped (2) — main thread requested shutdown.
-        if (result == 2) break;
-    }
+    // An empty CFRunLoop returns immediately. Keep a source installed for the
+    // lifetime of this thread so startup cannot turn into a CPU-burning spin
+    // before the first AX observer is registered.
+    var source_context: c.CFRunLoopSourceContext = std.mem.zeroes(c.CFRunLoopSourceContext);
+    source_context.perform = axThreadKeepalivePerform;
+    const keepalive_source = c.CFRunLoopSourceCreate(null, 0, &source_context) orelse {
+        log.err("failed to create AX thread keepalive source", .{});
+        g_ax_thread_runloop = null;
+        g_ax_thread_ready.store(true, .release);
+        return null;
+    };
+    defer c.CFRelease(@ptrCast(keepalive_source));
+    c.CFRunLoopAddSource(run_loop, keepalive_source, c.kCFRunLoopDefaultMode);
+    defer c.CFRunLoopRemoveSource(run_loop, keepalive_source, c.kCFRunLoopDefaultMode);
+
+    g_ax_thread_ready.store(true, .release);
+    c.CFRunLoopRun();
 
     return null;
 }
@@ -193,6 +204,12 @@ fn startAxThread() void {
     // (< 1ms) because the thread does nothing before signaling readiness.
     while (!g_ax_thread_ready.load(.acquire)) {
         std.atomic.spinLoopHint();
+    }
+
+    if (g_ax_thread_runloop == null) {
+        _ = c.pthread_join(thread, null);
+        g_ax_thread = null;
+        g_ax_thread_ready.store(false, .release);
     }
 }
 
@@ -218,6 +235,9 @@ pub fn init() void {
 pub fn deinit() void {
     cancelRuntimeSources();
 
+    // Detach sources first, then join the observer thread before releasing
+    // anything a callback can read. CFRunLoopStop alone does not wait for an
+    // in-flight callback to return.
     var i: u32 = 0;
     while (i < g_app_observer_count) : (i += 1) {
         const observer = g_app_observers[i].observer;
@@ -229,9 +249,21 @@ pub fn deinit() void {
                 c.kCFRunLoopDefaultMode,
             );
         }
+    }
+    stopAxThread();
+
+    i = 0;
+    while (i < g_app_observer_count) : (i += 1) {
+        const observer = g_app_observers[i].observer;
+        if (observer == null) continue;
         c.CFRelease(@ptrCast(observer));
     }
+
+    c.os_unfair_lock_lock(&g_ax_lock);
     g_app_observer_count = 0;
+    g_app_observers = [_]AppObserverEntry{.{}} ** max_observed_apps;
+    c.os_unfair_lock_unlock(&g_ax_lock);
+
     g_observe_retry_count = 0;
     g_window_scan_idle_ticks = 0;
 
@@ -240,7 +272,6 @@ pub fn deinit() void {
     }
 
     deinitAxObserverStrings();
-    stopAxThread();
 }
 
 pub fn observeApp(pid: i32) void {
@@ -271,11 +302,13 @@ pub fn unobserveApp(pid: i32) void {
 fn cancelRuntimeSources() void {
     if (g_observe_retry_source) |source| {
         c.dispatch_source_cancel(source);
+        c.dispatch_release(.{ ._ds = source });
         g_observe_retry_source = null;
     }
 
     if (g_window_scan_source) |source| {
         c.dispatch_source_cancel(source);
+        c.dispatch_release(.{ ._ds = source });
         g_window_scan_source = null;
     }
 }
@@ -356,6 +389,7 @@ fn observeRetryStopIfIdle() void {
     if (g_observe_retry_count != 0) return;
     if (g_observe_retry_source) |source| {
         c.dispatch_source_cancel(source);
+        c.dispatch_release(.{ ._ds = source });
         g_observe_retry_source = null;
     }
 }
@@ -454,6 +488,7 @@ fn updateWindowScanSource() void {
     if (g_app_observer_count == 0) {
         if (g_window_scan_source) |source| {
             c.dispatch_source_cancel(source);
+            c.dispatch_release(.{ ._ds = source });
             g_window_scan_source = null;
         }
         return;
@@ -568,6 +603,7 @@ fn processWindowScanTick() void {
     if (g_window_scan_idle_ticks >= window_scan_idle_limit) {
         if (g_window_scan_source) |source| {
             c.dispatch_source_cancel(source);
+            c.dispatch_release(.{ ._ds = source });
             g_window_scan_source = null;
         }
     }
@@ -687,6 +723,11 @@ fn axNotificationHandler(
     notification: c.CFStringRef,
     refcon: ?*anyopaque,
 ) callconv(.c) void {
+    // Keep the observer alive if the main thread concurrently unobserves the
+    // app after this callback has been entered.
+    _ = c.CFRetain(@ptrCast(observer));
+    defer c.CFRelease(@ptrCast(observer));
+
     const strings = ensureAxObserverStrings() orelse return;
 
     const pid = refconPid(refcon);
@@ -775,6 +816,16 @@ fn removeAppObserverAtIndex(index: u32) void {
     if (index >= g_app_observer_count) return;
 
     const observer = g_app_observers[index].observer;
+
+    // Publish removal before dropping the source. A callback already in
+    // flight must fail its appObserverIndex lookup instead of mutating an
+    // entry that is about to be replaced.
+    c.os_unfair_lock_lock(&g_ax_lock);
+    g_app_observer_count -= 1;
+    g_app_observers[index] = g_app_observers[g_app_observer_count];
+    g_app_observers[g_app_observer_count] = .{};
+    c.os_unfair_lock_unlock(&g_ax_lock);
+
     if (observer != null) {
         if (g_ax_thread_runloop) |rl| {
             c.CFRunLoopRemoveSource(
@@ -785,13 +836,6 @@ fn removeAppObserverAtIndex(index: u32) void {
         }
         c.CFRelease(@ptrCast(observer));
     }
-
-    // Lock the array swap so the background thread's appObserverIndex sees
-    // a consistent view.
-    c.os_unfair_lock_lock(&g_ax_lock);
-    g_app_observer_count -= 1;
-    g_app_observers[index] = g_app_observers[g_app_observer_count];
-    c.os_unfair_lock_unlock(&g_ax_lock);
 
     updateWindowScanSource();
 }

--- a/src/c/cg_extra.zig
+++ b/src/c/cg_extra.zig
@@ -19,6 +19,8 @@ const c = @import("c");
 
 pub extern fn CGEventGetFlags(event: c.CGEventRef) c.CGEventFlags;
 
+pub extern fn CGEventGetLocation(event: c.CGEventRef) c.CGPoint;
+
 pub extern fn CGEventGetIntegerValueField(
     event: c.CGEventRef,
     field: c.CGEventField,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -12,6 +12,7 @@ const posix = std.posix;
 const build_options = @import("build_options");
 const log_options = @import("log_options.zig");
 const osutil = @import("osutil.zig");
+const runtime_paths = @import("runtime_paths.zig");
 
 pub const std_options = std.Options{
     .log_level = log_options.level,
@@ -186,7 +187,7 @@ fn runClient(cmd: []const u8) u8 {
     var transport_failed = false;
 
     var path_buf: [128]u8 = undefined;
-    const path = std.fmt.bufPrintSentinel(&path_buf, "/tmp/bobrwm_{d}.sock", .{std.c.getuid()}, 0) catch {
+    const path = runtime_paths.socketPathBuf(&path_buf) catch {
         writeStderr("error: socket path too long\n");
         return 1;
     };
@@ -207,8 +208,12 @@ fn runClient(cmd: []const u8) u8 {
     };
 
     var addr: posix.sockaddr.un = .{ .path = undefined, .family = posix.AF.UNIX };
+    if (path.len >= addr.path.len) {
+        writeStderr("error: socket path too long\n");
+        return 1;
+    }
     @memcpy(addr.path[0..path.len], path[0..path.len]);
-    if (path.len < addr.path.len) addr.path[path.len] = 0;
+    addr.path[path.len] = 0;
 
     log.debug("[trace] ipc client connecting path={s} cmd={s}", .{ path, cmd });
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -136,7 +136,7 @@ const help_text =
     \\  version                  Show version information
     \\
     \\Window Commands (IPC):
-    \\  retile                    Re-tile all windows on the active workspace
+    \\  retile                    Re-tile visible workspaces on all displays
     \\  reload-config             Reload config, keeping current config on failure
     \\  toggle-split              Cycle BSP split mode (auto, horizontal, vertical)
     \\  focus <direction>         Focus window in direction (left, right, up, down)
@@ -150,7 +150,6 @@ const help_text =
     \\BSP Layout Commands (IPC):
     \\  bsp ratio rel <delta>     Adjust focused split ratio relatively
     \\  bsp ratio abs <ratio>     Set focused split ratio absolutely
-    \\  bsp insert-mode <mode>    Set insert mode (split, stack)
     \\  bsp insert-point <point>  Set insertion point (focused, first, last, min_depth)
     \\  bsp mirror <axis>         Mirror layout (horizontal, vertical)
     \\  bsp equalize              Reset all split ratios to default

--- a/src/config.zig
+++ b/src/config.zig
@@ -171,7 +171,7 @@ pub const Action = enum(u8) {
     comptime {
         // stringToEnum builds a StaticStringMap whose pdq sort blows past
         // the default branch quota when the enum has many fields.
-        @setEvalBranchQuota(20_000);
+        @setEvalBranchQuota(40_000);
         const event = @import("event.zig").EventKind;
         for (@typeInfo(Action).@"enum".fields) |f| {
             // Verify each Action.<name> has a matching EventKind.hk_<name>;

--- a/src/config.zig
+++ b/src/config.zig
@@ -183,6 +183,10 @@ pub const Action = enum(u8) {
     }
 };
 
+/// Sentinel arguments for relative display movement in keybinds.
+pub const next_display_arg: u8 = 0;
+pub const previous_display_arg: u8 = std.math.maxInt(u8);
+
 pub const Keybind = struct {
     key: []const u8,
     mods: Mods = .{},
@@ -531,7 +535,10 @@ fn validateKeybinds(keybinds: []const Keybind, workspace_count: usize) !void {
                 }
             },
             .move_workspace_to_display => {
-                if (keybind.arg == 0 or keybind.arg > workspace.max_displays) {
+                const is_relative = keybind.arg == next_display_arg or
+                    keybind.arg == previous_display_arg;
+                const is_explicit = keybind.arg > 0 and keybind.arg <= workspace.max_displays;
+                if (!is_relative and !is_explicit) {
                     return error.InvalidKeybindDisplay;
                 }
             },
@@ -810,6 +817,22 @@ test "validate rejects invalid workspace references and duplicate rules" {
         },
     };
     try t.expectError(error.DuplicateAppRule, validate(&duplicate_rules));
+}
+
+test "validate accepts relative display keybind targets" {
+    const keybinds = [_]Keybind{
+        .{ .key = "n", .action = .move_workspace_to_display, .arg = next_display_arg },
+        .{ .key = "p", .action = .move_workspace_to_display, .arg = previous_display_arg },
+        .{ .key = "1", .action = .move_workspace_to_display, .arg = 1 },
+    };
+    const cfg: Config = .{ .keybinds = &keybinds };
+    try validate(&cfg);
+
+    const invalid_keybinds = [_]Keybind{
+        .{ .key = "9", .action = .move_workspace_to_display, .arg = workspace.max_displays + 1 },
+    };
+    const invalid: Config = .{ .keybinds = &invalid_keybinds };
+    try t.expectError(error.InvalidKeybindDisplay, validate(&invalid));
 }
 
 test "validate rejects unknown keys and invalid workspace name text" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -480,15 +480,22 @@ fn isDefaultKeybindSlice(keybinds: []const Keybind) bool {
 
 // Loading
 
+/// Number of workspaces this configuration creates at startup. An omitted
+/// name list selects the full default set rather than zero workspaces.
+pub fn workspaceCount(config: *const Config) u8 {
+    std.debug.assert(config.workspace_names.len <= workspace.max_workspaces);
+    return if (config.workspace_names.len == 0)
+        workspace.max_workspaces
+    else
+        @intCast(config.workspace_names.len);
+}
+
 /// Reject values that parse as valid ZON but violate runtime invariants.
 /// Validation happens before a config becomes visible to the main loop, so a
 /// bad reload leaves the last known-good config intact.
 pub fn validate(config: *const Config) !void {
     if (config.workspace_names.len > workspace.max_workspaces) return error.TooManyWorkspaces;
-    const workspace_count: usize = if (config.workspace_names.len == 0)
-        workspace.max_workspaces
-    else
-        config.workspace_names.len;
+    const workspace_count = workspaceCount(config);
 
     for (config.workspace_names) |name| {
         if (!std.unicode.utf8ValidateSlice(name) or std.mem.indexOfScalar(u8, name, 0) != null) {
@@ -765,9 +772,11 @@ test "default config" {
 test "validate accepts defaults and a reduced workspace set" {
     const defaults: Config = .{};
     try validate(&defaults);
+    try t.expectEqual(workspace.max_workspaces, workspaceCount(&defaults));
 
     const reduced: Config = .{ .workspace_names = &.{ "term", "web", "code", "chat" } };
     try validate(&reduced);
+    try t.expectEqual(@as(u8, 4), workspaceCount(&reduced));
 }
 
 test "validate rejects geometry and gesture values that are not finite or bounded" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -7,6 +7,7 @@ const shim = @import("shim_api.zig");
 const tiling = @import("tiling.zig");
 const osutil = @import("osutil.zig");
 const animation = @import("animation.zig");
+const workspace = @import("workspace.zig");
 
 const log = std.log.scoped(.config);
 
@@ -317,6 +318,8 @@ pub const SwipeConfig = struct {
     reverse: bool = false,
 };
 
+pub const max_swipe_fingers: u8 = 16;
+
 /// Inactive-window dimming via owned black overlay panels. When enabled, every
 /// visible managed window except the focused one gets a click-through black
 /// overlay at `level` opacity, giving a clean multiplicative darken with no
@@ -473,6 +476,98 @@ fn isDefaultKeybindSlice(keybinds: []const Keybind) bool {
 
 // Loading
 
+/// Reject values that parse as valid ZON but violate runtime invariants.
+/// Validation happens before a config becomes visible to the main loop, so a
+/// bad reload leaves the last known-good config intact.
+pub fn validate(config: *const Config) !void {
+    if (config.workspace_names.len > workspace.max_workspaces) return error.TooManyWorkspaces;
+    const workspace_count: usize = if (config.workspace_names.len == 0)
+        workspace.max_workspaces
+    else
+        config.workspace_names.len;
+
+    for (config.workspace_names) |name| {
+        if (!std.unicode.utf8ValidateSlice(name) or std.mem.indexOfScalar(u8, name, 0) != null) {
+            return error.InvalidWorkspaceName;
+        }
+    }
+
+    if (!std.math.isFinite(config.bsp_split_ratio) or
+        config.bsp_split_ratio < 0.1 or
+        config.bsp_split_ratio > 0.9)
+    {
+        return error.InvalidBspSplitRatio;
+    }
+    if (!std.math.isFinite(config.dimmed_inactive.level) or
+        config.dimmed_inactive.level < 0 or
+        config.dimmed_inactive.level > 1)
+    {
+        return error.InvalidDimLevel;
+    }
+    if (config.swipe.fingers == 0 or config.swipe.fingers > max_swipe_fingers) {
+        return error.InvalidSwipeFingerCount;
+    }
+    if (!std.math.isFinite(config.swipe.distance_pct) or
+        config.swipe.distance_pct <= 0 or
+        config.swipe.distance_pct > 1)
+    {
+        return error.InvalidSwipeDistance;
+    }
+
+    try validateKeybinds(config.keybinds, workspace_count);
+    try validateAppRules(config.app_rules, workspace_count);
+    try validateWorkspaceAssignments(config.workspace_assignments, workspace_count);
+}
+
+fn validateKeybinds(keybinds: []const Keybind, workspace_count: usize) !void {
+    const validate_targets = !isDefaultKeybindSlice(keybinds);
+    for (keybinds) |keybind| {
+        if (keyNameToCode(keybind.key) == null) return error.UnknownKeyName;
+        if (!validate_targets) continue;
+        switch (keybind.action) {
+            .focus_workspace, .move_to_workspace => {
+                if (keybind.arg == 0 or @as(usize, keybind.arg) > workspace_count) {
+                    return error.InvalidKeybindWorkspace;
+                }
+            },
+            .move_workspace_to_display => {
+                if (keybind.arg == 0 or keybind.arg > workspace.max_displays) {
+                    return error.InvalidKeybindDisplay;
+                }
+            },
+            else => {},
+        }
+    }
+}
+
+fn validateAppRules(rules: []const AppRule, workspace_count: usize) !void {
+    for (rules, 0..) |rule, i| {
+        if (rule.app_id.len == 0) return error.EmptyAppId;
+        if (rule.workspace) |workspace_id| {
+            if (workspace_id == 0 or @as(usize, workspace_id) > workspace_count) {
+                return error.InvalidAppRuleWorkspace;
+            }
+        }
+        for (rules[0..i]) |previous| {
+            if (std.mem.eql(u8, previous.app_id, rule.app_id)) return error.DuplicateAppRule;
+        }
+    }
+}
+
+fn validateWorkspaceAssignments(assignments: []const WorkspaceAssignment, workspace_count: usize) !void {
+    for (assignments, 0..) |assignment, i| {
+        if (assignment.app_id.len == 0) return error.EmptyAppId;
+        if (assignment.workspace == 0 or @as(usize, assignment.workspace) > workspace_count) {
+            return error.InvalidWorkspaceAssignment;
+        }
+        for (assignments[0..i]) |previous| {
+            if (std.mem.eql(u8, previous.app_id, assignment.app_id)) {
+                return error.DuplicateWorkspaceAssignment;
+            }
+        }
+    }
+}
+
 pub fn load(allocator: std.mem.Allocator, explicit_path: ?[]const u8) Config {
     const path = resolvePath(allocator, explicit_path) catch return .{};
     defer allocator.free(path);
@@ -517,6 +612,10 @@ pub fn loadFromPath(allocator: std.mem.Allocator, path: []const u8) ?Config {
     // asserts at comptime that T contains no allocator-managed types.
     const parsed = std.zon.parse.fromSliceAlloc(Config, allocator, source, null, .{}) catch |err| {
         log.err("failed to parse {s}: {}", .{ path, err });
+        return null;
+    };
+    validate(&parsed) catch |err| {
+        log.err("invalid config {s}: {}", .{ path, err });
         return null;
     };
 
@@ -654,6 +753,75 @@ test "default config" {
     try t.expect(!cfg.animation.enabled);
     try t.expectEqual(@as(u64, 200), cfg.animation.duration_ms);
     try t.expectEqual(animation.Easing.ease_out, cfg.animation.easing);
+}
+
+test "validate accepts defaults and a reduced workspace set" {
+    const defaults: Config = .{};
+    try validate(&defaults);
+
+    const reduced: Config = .{ .workspace_names = &.{ "term", "web", "code", "chat" } };
+    try validate(&reduced);
+}
+
+test "validate rejects geometry and gesture values that are not finite or bounded" {
+    var cfg: Config = .{};
+
+    cfg.bsp_split_ratio = std.math.inf(f64);
+    try t.expectError(error.InvalidBspSplitRatio, validate(&cfg));
+
+    cfg = .{};
+    cfg.dimmed_inactive.level = std.math.nan(f32);
+    try t.expectError(error.InvalidDimLevel, validate(&cfg));
+
+    cfg = .{};
+    cfg.swipe.fingers = max_swipe_fingers + 1;
+    try t.expectError(error.InvalidSwipeFingerCount, validate(&cfg));
+
+    cfg = .{};
+    cfg.swipe.distance_pct = std.math.nan(f64);
+    try t.expectError(error.InvalidSwipeDistance, validate(&cfg));
+}
+
+test "validate rejects invalid workspace references and duplicate rules" {
+    const too_many_names: Config = .{
+        .workspace_names = &.{ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11" },
+    };
+    try t.expectError(error.TooManyWorkspaces, validate(&too_many_names));
+
+    const invalid_keybinds = [_]Keybind{
+        .{ .key = "1", .mods = .{ .alt = true }, .action = .focus_workspace, .arg = 5 },
+    };
+    const bad_keybind: Config = .{
+        .workspace_names = &.{ "1", "2", "3", "4" },
+        .keybinds = &invalid_keybinds,
+    };
+    try t.expectError(error.InvalidKeybindWorkspace, validate(&bad_keybind));
+
+    const bad_assignment: Config = .{
+        .workspace_names = &.{ "1", "2" },
+        .workspace_assignments = &.{.{ .app_id = "com.example.App", .workspace = 0 }},
+    };
+    try t.expectError(error.InvalidWorkspaceAssignment, validate(&bad_assignment));
+
+    const duplicate_rules: Config = .{
+        .app_rules = &.{
+            .{ .app_id = "com.example.App", .float = true },
+            .{ .app_id = "com.example.App", .workspace = 2 },
+        },
+    };
+    try t.expectError(error.DuplicateAppRule, validate(&duplicate_rules));
+}
+
+test "validate rejects unknown keys and invalid workspace name text" {
+    const keybinds = [_]Keybind{
+        .{ .key = "F1", .mods = .{ .alt = true }, .action = .focus_left },
+    };
+    const unknown_key: Config = .{ .keybinds = &keybinds };
+    try t.expectError(error.UnknownKeyName, validate(&unknown_key));
+
+    const invalid_utf8 = [_]u8{0xff};
+    const invalid_name: Config = .{ .workspace_names = &.{invalid_utf8[0..]} };
+    try t.expectError(error.InvalidWorkspaceName, validate(&invalid_name));
 }
 
 test "default_keybinds" {

--- a/src/event.zig
+++ b/src/event.zig
@@ -16,6 +16,7 @@ pub const EventKind = enum(u8) {
     mouse_down = 13,
     mouse_up = 14,
     role_poll_tick = 15,
+    mouse_dragged = 16,
 
     hk_focus_workspace = 20,
     hk_move_to_workspace = 21,

--- a/src/filelog.zig
+++ b/src/filelog.zig
@@ -9,8 +9,8 @@
 //! belongs on the terminal.
 
 const std = @import("std");
-const osutil = @import("osutil.zig");
 const log_options = @import("log_options.zig");
+const runtime_paths = @import("runtime_paths.zig");
 
 const log = std.log.scoped(.filelog);
 
@@ -47,20 +47,46 @@ const Tm = extern struct {
 /// Open the log file. Call once from the main thread before any observer
 /// threads start, so `logFn` never races on the descriptor.
 pub fn init() void {
-    var path_buf: [64]u8 = undefined;
-    const path = std.fmt.bufPrintSentinel(
-        &path_buf,
-        "/tmp/bobrwm_{d}.log",
-        .{std.c.getuid()},
-        0,
-    ) catch return;
+    runtime_paths.ensureRuntimeDir(std.heap.c_allocator) catch |err| {
+        log.warn("could not secure runtime directory: {}; logging to stderr only", .{err});
+        return;
+    };
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = runtime_paths.logPathBuf(&path_buf) catch |err| {
+        log.warn("could not resolve log path: {}; logging to stderr only", .{err});
+        return;
+    };
 
     // Appending keeps the tail that explains a crash, which matters now that
     // launchd restarts the agent on one.
-    const flags: std.c.O = .{ .ACCMODE = .WRONLY, .CREAT = true, .APPEND = true };
-    const fd = std.c.open(path, flags, @as(std.c.mode_t, 0o644));
+    const flags: std.c.O = .{
+        .ACCMODE = .WRONLY,
+        .CREAT = true,
+        .APPEND = true,
+        .NONBLOCK = true,
+        .NOFOLLOW = true,
+        .CLOEXEC = true,
+    };
+    const fd = std.c.open(path, flags, @as(std.c.mode_t, 0o600));
     if (fd < 0) {
         log.warn("could not open {s}; logging to stderr only", .{path});
+        return;
+    }
+
+    var stat: std.c.Stat = undefined;
+    if (std.c.fstat(fd, &stat) != 0 or
+        !std.c.S.ISREG(stat.mode) or
+        stat.uid != std.c.getuid() or
+        stat.nlink != 1)
+    {
+        log.warn("refusing unsafe log path {s}; logging to stderr only", .{path});
+        _ = std.c.close(fd);
+        return;
+    }
+    if (std.c.fchmod(fd, 0o600) != 0) {
+        log.warn("could not secure {s}; logging to stderr only", .{path});
+        _ = std.c.close(fd);
         return;
     }
 
@@ -71,6 +97,11 @@ pub fn init() void {
 
     g_fd.store(fd, .release);
     log.info("logging to {s}", .{path});
+}
+
+pub fn deinit() void {
+    const fd = g_fd.swap(-1, .acq_rel);
+    if (fd >= 0) _ = std.c.close(fd);
 }
 
 /// `std.Options.logFn`. Writes to stderr as usual, then appends a plain-text

--- a/src/geometry.zig
+++ b/src/geometry.zig
@@ -18,6 +18,10 @@ const Frame = window_mod.Window.Frame;
 /// when WindowServer still returns its previous frame. Matching notifications
 /// remain manager-owned after the deadline because delivery itself can lag.
 pub const default_settle_interval_ns: i128 = 500 * std.time.ns_per_ms;
+/// Delay before re-reading WindowServer after an AX notification. The first
+/// read can precede the physical update and no second notification is
+/// guaranteed, so every notification requires one trailing sample.
+pub const default_resample_delay_ns: i128 = 75 * std.time.ns_per_ms;
 
 pub const IntentSource = enum {
     layout,
@@ -29,8 +33,26 @@ pub const IntentSource = enum {
     exit_restore,
 };
 
+pub const Position = struct {
+    x: f64,
+    y: f64,
+};
+
+pub const Target = union(enum) {
+    frame: Frame,
+    position: Position,
+
+    pub fn matches(self: Target, observed: Frame) bool {
+        return switch (self) {
+            .frame => |frame| observed.approxEqual(frame, Frame.tolerance),
+            .position => |position| @abs(observed.x - position.x) <= Frame.tolerance and
+                @abs(observed.y - position.y) <= Frame.tolerance,
+        };
+    }
+};
+
 pub const Intent = struct {
-    target: Frame,
+    target: Target,
     source: IntentSource,
     generation: u64,
     accepted_at_ns: i128,
@@ -43,11 +65,18 @@ pub const Entry = struct {
     /// Latest AX target accepted for this window, retained through its echo
     /// window so stale notifications cannot take ownership of stored state.
     intent: ?Intent = null,
+    /// Absolute time for the mandatory trailing WindowServer sample.
+    resample_at_ns: ?i128 = null,
 };
 
 pub const ObservationOwner = enum {
     manager,
     user,
+    external,
+};
+
+pub const SettlementOwner = enum {
+    manager,
     external,
 };
 
@@ -83,15 +112,18 @@ pub fn ensureTotalCapacity(self: *Self, capacity: u32) !void {
 /// write replaces the prior intent and advances the generation, so delayed
 /// notifications from the prior write remain manager-owned during the new
 /// intent's settlement interval.
-pub fn recordAccepted(
+fn recordAccepted(
     self: *Self,
     wid: WindowId,
-    target: Frame,
+    target: Target,
     source: IntentSource,
     now_ns: i128,
 ) !Intent {
     std.debug.assert(wid > 0);
-    std.debug.assert(target.width > 0 and target.height > 0);
+    switch (target) {
+        .frame => |frame| std.debug.assert(frame.width > 0 and frame.height > 0),
+        .position => {},
+    }
 
     const generation = self.next_generation;
     if (generation == std.math.maxInt(u64)) return error.GenerationExhausted;
@@ -109,7 +141,56 @@ pub fn recordAccepted(
     const result = try self.entries.getOrPut(self.allocator, wid);
     if (!result.found_existing) result.value_ptr.* = .{};
     result.value_ptr.intent = intent;
+    result.value_ptr.resample_at_ns = std.math.add(i128, now_ns, default_resample_delay_ns) catch
+        std.math.maxInt(i128);
     return intent;
+}
+
+pub fn recordFrameAccepted(
+    self: *Self,
+    wid: WindowId,
+    target: Frame,
+    source: IntentSource,
+    now_ns: i128,
+) !Intent {
+    return self.recordAccepted(wid, .{ .frame = target }, source, now_ns);
+}
+
+pub fn recordFrameAcceptedFor(
+    self: *Self,
+    wid: WindowId,
+    target: Frame,
+    source: IntentSource,
+    now_ns: i128,
+    settle_interval_ns: i128,
+) !Intent {
+    std.debug.assert(settle_interval_ns > 0);
+    _ = try self.recordFrameAccepted(wid, target, source, now_ns);
+    const entry = self.entries.getPtr(wid).?;
+    entry.intent.?.settle_deadline_ns = std.math.add(i128, now_ns, settle_interval_ns) catch
+        std.math.maxInt(i128);
+    return entry.intent.?;
+}
+
+pub fn recordPositionAccepted(
+    self: *Self,
+    wid: WindowId,
+    x: f64,
+    y: f64,
+    source: IntentSource,
+    now_ns: i128,
+) !Intent {
+    return self.recordAccepted(wid, .{ .position = .{ .x = x, .y = y } }, source, now_ns);
+}
+
+/// Seed a newly discovered physical frame without manufacturing a geometry
+/// notification or settlement timer. Existing intent is preserved for ID
+/// replacement paths that successfully wrote the replacement before adoption.
+pub fn seedObserved(self: *Self, wid: WindowId, observed: Frame) !void {
+    std.debug.assert(wid > 0);
+    const result = try self.entries.getOrPut(self.allocator, wid);
+    if (!result.found_existing) result.value_ptr.* = .{};
+    result.value_ptr.observed = observed;
 }
 
 /// Classify a WindowServer observation. Only the exact window identified as
@@ -129,6 +210,8 @@ pub fn observe(
     if (!result.found_existing) result.value_ptr.* = .{};
     const entry = result.value_ptr;
     entry.observed = observed;
+    entry.resample_at_ns = std.math.add(i128, now_ns, default_resample_delay_ns) catch
+        std.math.maxInt(i128);
 
     if (dragged_wid == wid) {
         entry.intent = null;
@@ -137,7 +220,7 @@ pub fn observe(
 
     if (entry.intent) |intent| {
         const still_settling = now_ns <= intent.settle_deadline_ns;
-        const reached_target = observed.approxEqual(intent.target, Frame.tolerance);
+        const reached_target = intent.target.matches(observed);
         if (still_settling or reached_target) {
             // Once a delayed notification confirms the target after the grace
             // interval, retain the observation but release the old intent.
@@ -148,6 +231,79 @@ pub fn observe(
     }
 
     return .external;
+}
+
+/// Record the mandatory trailing WindowServer sample. A manager intent keeps
+/// ownership while it is still settling; a divergent sample after its
+/// deadline is external. Matching samples retain the intent until its deadline
+/// so another late notification from the same AX write cannot steal ownership.
+pub fn settle(self: *Self, wid: WindowId, observed: Frame, now_ns: i128) SettlementOwner {
+    const entry = self.entries.getPtr(wid) orelse return .external;
+    entry.observed = observed;
+    entry.resample_at_ns = null;
+
+    if (entry.intent) |intent| {
+        const reached_target = intent.target.matches(observed);
+        if (now_ns <= intent.settle_deadline_ns) {
+            entry.resample_at_ns = if (reached_target)
+                intent.settle_deadline_ns
+            else
+                std.math.add(i128, now_ns, default_resample_delay_ns) catch std.math.maxInt(i128);
+            return .manager;
+        }
+        entry.intent = null;
+        if (reached_target) return .manager;
+    }
+
+    return .external;
+}
+
+/// Collect due trailing samples without allocating. Entries beyond `out` stay
+/// armed for the next timer tick; callers can therefore use a fixed buffer
+/// without silently losing reconciliation work.
+pub fn collectDueResamples(self: *Self, now_ns: i128, out: []WindowId) usize {
+    var count: usize = 0;
+    var it = self.entries.iterator();
+    while (it.next()) |entry| {
+        const due = entry.value_ptr.resample_at_ns orelse continue;
+        if (due > now_ns) continue;
+        if (count == out.len) break;
+        out[count] = entry.key_ptr.*;
+        count += 1;
+        entry.value_ptr.resample_at_ns = null;
+    }
+    return count;
+}
+
+pub fn hasPendingResamples(self: *const Self) bool {
+    var it = self.entries.valueIterator();
+    while (it.next()) |entry| {
+        if (entry.resample_at_ns != null) return true;
+    }
+    return false;
+}
+
+pub fn deferResample(self: *Self, wid: WindowId, now_ns: i128) void {
+    const entry = self.entries.getPtr(wid) orelse return;
+    entry.resample_at_ns = std.math.add(i128, now_ns, default_resample_delay_ns) catch
+        std.math.maxInt(i128);
+}
+
+/// Whether a physical observation proves the window is away from a desired
+/// frame. An outstanding write to that same frame owns the settlement window,
+/// so its potentially stale observation must not trigger a duplicate write.
+pub fn needsRepair(self: *const Self, wid: WindowId, desired: Frame, now_ns: i128) bool {
+    const entry = self.entries.get(wid) orelse return false;
+    if (entry.intent) |intent| {
+        if (now_ns <= intent.settle_deadline_ns) {
+            switch (intent.target) {
+                .frame => |target| if (target.approxEqual(desired, Frame.tolerance)) return false,
+                .position => {},
+            }
+        }
+    }
+    const observed = entry.observed orelse return false;
+    return !observed.approxEqual(desired, Frame.tolerance);
 }
 
 pub fn get(self: *const Self, wid: WindowId) ?Entry {
@@ -172,7 +328,7 @@ test "stale observation inside settlement interval remains manager owned" {
     var coordinator = Self.initWithSettleInterval(testing.allocator, 100);
     defer coordinator.deinit();
 
-    _ = try coordinator.recordAccepted(10, fullscreen, .layout, 1_000);
+    _ = try coordinator.recordFrameAccepted(10, fullscreen, .layout, 1_000);
     try testing.expectEqual(
         ObservationOwner.manager,
         try coordinator.observe(10, tiled, 1_050, null),
@@ -185,7 +341,7 @@ test "matching delayed observation is still manager owned" {
     var coordinator = Self.initWithSettleInterval(testing.allocator, 100);
     defer coordinator.deinit();
 
-    _ = try coordinator.recordAccepted(10, fullscreen, .layout, 1_000);
+    _ = try coordinator.recordFrameAccepted(10, fullscreen, .layout, 1_000);
     try testing.expectEqual(
         ObservationOwner.manager,
         try coordinator.observe(10, fullscreen, 1_500, null),
@@ -197,7 +353,7 @@ test "divergent observation after settlement interval is external" {
     var coordinator = Self.initWithSettleInterval(testing.allocator, 100);
     defer coordinator.deinit();
 
-    _ = try coordinator.recordAccepted(10, fullscreen, .layout, 1_000);
+    _ = try coordinator.recordFrameAccepted(10, fullscreen, .layout, 1_000);
     try testing.expectEqual(
         ObservationOwner.external,
         try coordinator.observe(10, tiled, 1_101, null),
@@ -209,7 +365,7 @@ test "only the dragged window overrides manager ownership" {
     var coordinator = Self.initWithSettleInterval(testing.allocator, 100);
     defer coordinator.deinit();
 
-    _ = try coordinator.recordAccepted(10, fullscreen, .layout, 1_000);
+    _ = try coordinator.recordFrameAccepted(10, fullscreen, .layout, 1_000);
     try testing.expectEqual(
         ObservationOwner.manager,
         try coordinator.observe(10, tiled, 1_050, 20),
@@ -225,17 +381,17 @@ test "new accepted write supersedes the prior generation" {
     var coordinator = Self.initWithSettleInterval(testing.allocator, 100);
     defer coordinator.deinit();
 
-    const first = try coordinator.recordAccepted(10, fullscreen, .layout, 1_000);
-    const second = try coordinator.recordAccepted(10, tiled, .layout, 1_010);
+    const first = try coordinator.recordFrameAccepted(10, fullscreen, .layout, 1_000);
+    const second = try coordinator.recordFrameAccepted(10, tiled, .layout, 1_010);
     try testing.expectEqual(first.generation + 1, second.generation);
-    try testing.expect(coordinator.get(10).?.intent.?.target.approxEqual(tiled, Frame.tolerance));
+    try testing.expect(coordinator.get(10).?.intent.?.target.frame.approxEqual(tiled, Frame.tolerance));
 }
 
 test "clearIntents preserves physical observations" {
     var coordinator = Self.initWithSettleInterval(testing.allocator, 100);
     defer coordinator.deinit();
 
-    _ = try coordinator.recordAccepted(10, fullscreen, .layout, 1_000);
+    _ = try coordinator.recordFrameAccepted(10, fullscreen, .layout, 1_000);
     _ = try coordinator.observe(10, fullscreen, 1_001, null);
     coordinator.clearIntents();
 
@@ -248,7 +404,94 @@ test "forget removes all window geometry state" {
     var coordinator = Self.init(testing.allocator);
     defer coordinator.deinit();
 
-    _ = try coordinator.recordAccepted(10, fullscreen, .layout, 1_000);
+    _ = try coordinator.recordFrameAccepted(10, fullscreen, .layout, 1_000);
     coordinator.forget(10);
     try testing.expect(coordinator.get(10) == null);
+}
+
+test "seeding physical state does not arm reconciliation" {
+    var coordinator = Self.init(testing.allocator);
+    defer coordinator.deinit();
+
+    try coordinator.seedObserved(10, tiled);
+    var due: [1]WindowId = undefined;
+    try testing.expectEqual(@as(usize, 0), coordinator.collectDueResamples(std.math.maxInt(i128), &due));
+}
+
+test "position intent matches without requiring a known size" {
+    var coordinator = Self.initWithSettleInterval(testing.allocator, 100);
+    defer coordinator.deinit();
+
+    _ = try coordinator.recordPositionAccepted(10, 1507, 977, .workspace_park, 1_000);
+    const parked: Frame = .{ .x = 1507, .y = 977, .width = 750, .height = 941 };
+    try testing.expectEqual(
+        ObservationOwner.manager,
+        try coordinator.observe(10, parked, 1_500, null),
+    );
+}
+
+test "pending desired frame suppresses repair until settlement ends" {
+    var coordinator = Self.initWithSettleInterval(testing.allocator, 100);
+    defer coordinator.deinit();
+
+    _ = try coordinator.recordFrameAccepted(10, fullscreen, .layout, 1_000);
+    _ = try coordinator.observe(10, tiled, 1_001, null);
+    try testing.expect(!coordinator.needsRepair(10, fullscreen, 1_050));
+    try testing.expect(coordinator.needsRepair(10, fullscreen, 1_101));
+}
+
+test "every notification schedules a trailing physical sample" {
+    var coordinator = Self.init(testing.allocator);
+    defer coordinator.deinit();
+
+    _ = try coordinator.observe(10, tiled, 1_000, null);
+    var due: [1]WindowId = undefined;
+    try testing.expectEqual(@as(usize, 0), coordinator.collectDueResamples(1_000, &due));
+    try testing.expectEqual(
+        @as(usize, 1),
+        coordinator.collectDueResamples(1_000 + default_resample_delay_ns, &due),
+    );
+    try testing.expectEqual(@as(WindowId, 10), due[0]);
+}
+
+test "every accepted write schedules a trailing physical sample" {
+    var coordinator = Self.init(testing.allocator);
+    defer coordinator.deinit();
+
+    _ = try coordinator.recordFrameAccepted(10, fullscreen, .layout, 1_000);
+    var due: [1]WindowId = undefined;
+    try testing.expectEqual(
+        @as(usize, 1),
+        coordinator.collectDueResamples(1_000 + default_resample_delay_ns, &due),
+    );
+    try testing.expectEqual(@as(WindowId, 10), due[0]);
+}
+
+test "trailing divergence after an old intent becomes external" {
+    var coordinator = Self.initWithSettleInterval(testing.allocator, 100);
+    defer coordinator.deinit();
+
+    _ = try coordinator.recordFrameAccepted(10, tiled, .layout, 1_000);
+    // The immediate notification still sees the old target and looks like a
+    // delayed manager echo even though an external resize is in progress.
+    try testing.expectEqual(
+        ObservationOwner.manager,
+        try coordinator.observe(10, tiled, 1_500, null),
+    );
+    try testing.expectEqual(SettlementOwner.external, coordinator.settle(10, fullscreen, 1_600));
+}
+
+test "trailing manager divergence resamples until its deadline" {
+    var coordinator = Self.initWithSettleInterval(testing.allocator, 1_000);
+    defer coordinator.deinit();
+
+    _ = try coordinator.recordFrameAccepted(10, fullscreen, .layout, 1_000);
+    try testing.expectEqual(SettlementOwner.manager, coordinator.settle(10, tiled, 1_100));
+
+    var due: [1]WindowId = undefined;
+    try testing.expectEqual(@as(usize, 0), coordinator.collectDueResamples(1_100, &due));
+    try testing.expectEqual(
+        @as(usize, 1),
+        coordinator.collectDueResamples(1_100 + default_resample_delay_ns, &due),
+    );
 }

--- a/src/geometry.zig
+++ b/src/geometry.zig
@@ -1,0 +1,254 @@
+//! Tracks geometry ownership across asynchronous AX and WindowServer updates.
+//!
+//! AX frame writes complete before the corresponding move/resize notifications
+//! arrive, and WindowServer bounds can still expose the previous frame when an
+//! early notification is handled. This module records bobrwm's accepted frame
+//! intents separately from observed physical frames so notification consumers
+//! can distinguish manager echoes from user or application-driven geometry.
+
+const Self = @This();
+
+const std = @import("std");
+const window_mod = @import("window.zig");
+
+const WindowId = window_mod.WindowId;
+const Frame = window_mod.Window.Frame;
+
+/// Notifications inside this interval belong to the accepted AX write even
+/// when WindowServer still returns its previous frame. Matching notifications
+/// remain manager-owned after the deadline because delivery itself can lag.
+pub const default_settle_interval_ns: i128 = 500 * std.time.ns_per_ms;
+
+pub const IntentSource = enum {
+    layout,
+    workspace_park,
+    floating_restore,
+    user_command,
+    animation,
+    tab_sync,
+    exit_restore,
+};
+
+pub const Intent = struct {
+    target: Frame,
+    source: IntentSource,
+    generation: u64,
+    accepted_at_ns: i128,
+    settle_deadline_ns: i128,
+};
+
+pub const Entry = struct {
+    /// Most recent bounds sampled from WindowServer, never a desired frame.
+    observed: ?Frame = null,
+    /// Latest AX target accepted for this window, retained through its echo
+    /// window so stale notifications cannot take ownership of stored state.
+    intent: ?Intent = null,
+};
+
+pub const ObservationOwner = enum {
+    manager,
+    user,
+    external,
+};
+
+allocator: std.mem.Allocator,
+entries: std.AutoHashMapUnmanaged(WindowId, Entry) = .empty,
+next_generation: u64 = 1,
+settle_interval_ns: i128,
+
+pub fn init(allocator: std.mem.Allocator) Self {
+    return initWithSettleInterval(allocator, default_settle_interval_ns);
+}
+
+pub fn initWithSettleInterval(allocator: std.mem.Allocator, settle_interval_ns: i128) Self {
+    std.debug.assert(settle_interval_ns > 0);
+    return .{
+        .allocator = allocator,
+        .settle_interval_ns = settle_interval_ns,
+    };
+}
+
+pub fn deinit(self: *Self) void {
+    self.entries.deinit(self.allocator);
+}
+
+/// Reserve coordinator entries before window discovery starts. Geometry
+/// tracking must not become the first allocation attempted after AX has
+/// already accepted a write.
+pub fn ensureTotalCapacity(self: *Self, capacity: u32) !void {
+    try self.entries.ensureTotalCapacity(self.allocator, capacity);
+}
+
+/// Record a frame write only after AX accepted the full operation. A newer
+/// write replaces the prior intent and advances the generation, so delayed
+/// notifications from the prior write remain manager-owned during the new
+/// intent's settlement interval.
+pub fn recordAccepted(
+    self: *Self,
+    wid: WindowId,
+    target: Frame,
+    source: IntentSource,
+    now_ns: i128,
+) !Intent {
+    std.debug.assert(wid > 0);
+    std.debug.assert(target.width > 0 and target.height > 0);
+
+    const generation = self.next_generation;
+    if (generation == std.math.maxInt(u64)) return error.GenerationExhausted;
+    self.next_generation += 1;
+
+    const intent: Intent = .{
+        .target = target,
+        .source = source,
+        .generation = generation,
+        .accepted_at_ns = now_ns,
+        .settle_deadline_ns = std.math.add(i128, now_ns, self.settle_interval_ns) catch
+            std.math.maxInt(i128),
+    };
+
+    const result = try self.entries.getOrPut(self.allocator, wid);
+    if (!result.found_existing) result.value_ptr.* = .{};
+    result.value_ptr.intent = intent;
+    return intent;
+}
+
+/// Classify a WindowServer observation. Only the exact window identified as
+/// the active pointer drag can take user ownership; a mouse button held over a
+/// different window does not invalidate an outstanding manager intent.
+pub fn observe(
+    self: *Self,
+    wid: WindowId,
+    observed: Frame,
+    now_ns: i128,
+    dragged_wid: ?WindowId,
+) !ObservationOwner {
+    std.debug.assert(wid > 0);
+    std.debug.assert(observed.width >= 0 and observed.height >= 0);
+
+    const result = try self.entries.getOrPut(self.allocator, wid);
+    if (!result.found_existing) result.value_ptr.* = .{};
+    const entry = result.value_ptr;
+    entry.observed = observed;
+
+    if (dragged_wid == wid) {
+        entry.intent = null;
+        return .user;
+    }
+
+    if (entry.intent) |intent| {
+        const still_settling = now_ns <= intent.settle_deadline_ns;
+        const reached_target = observed.approxEqual(intent.target, Frame.tolerance);
+        if (still_settling or reached_target) {
+            // Once a delayed notification confirms the target after the grace
+            // interval, retain the observation but release the old intent.
+            if (!still_settling and reached_target) entry.intent = null;
+            return .manager;
+        }
+        entry.intent = null;
+    }
+
+    return .external;
+}
+
+pub fn get(self: *const Self, wid: WindowId) ?Entry {
+    return self.entries.get(wid);
+}
+
+pub fn forget(self: *Self, wid: WindowId) void {
+    _ = self.entries.remove(wid);
+}
+
+pub fn clearIntents(self: *Self) void {
+    var it = self.entries.valueIterator();
+    while (it.next()) |entry| entry.intent = null;
+}
+
+const testing = std.testing;
+
+const tiled: Frame = .{ .x = 4, .y = 37, .width = 750, .height = 941 };
+const fullscreen: Frame = .{ .x = 4, .y = 37, .width = 1504, .height = 941 };
+
+test "stale observation inside settlement interval remains manager owned" {
+    var coordinator = Self.initWithSettleInterval(testing.allocator, 100);
+    defer coordinator.deinit();
+
+    _ = try coordinator.recordAccepted(10, fullscreen, .layout, 1_000);
+    try testing.expectEqual(
+        ObservationOwner.manager,
+        try coordinator.observe(10, tiled, 1_050, null),
+    );
+    try testing.expect(coordinator.get(10).?.observed.?.approxEqual(tiled, Frame.tolerance));
+    try testing.expect(coordinator.get(10).?.intent != null);
+}
+
+test "matching delayed observation is still manager owned" {
+    var coordinator = Self.initWithSettleInterval(testing.allocator, 100);
+    defer coordinator.deinit();
+
+    _ = try coordinator.recordAccepted(10, fullscreen, .layout, 1_000);
+    try testing.expectEqual(
+        ObservationOwner.manager,
+        try coordinator.observe(10, fullscreen, 1_500, null),
+    );
+    try testing.expect(coordinator.get(10).?.intent == null);
+}
+
+test "divergent observation after settlement interval is external" {
+    var coordinator = Self.initWithSettleInterval(testing.allocator, 100);
+    defer coordinator.deinit();
+
+    _ = try coordinator.recordAccepted(10, fullscreen, .layout, 1_000);
+    try testing.expectEqual(
+        ObservationOwner.external,
+        try coordinator.observe(10, tiled, 1_101, null),
+    );
+    try testing.expect(coordinator.get(10).?.intent == null);
+}
+
+test "only the dragged window overrides manager ownership" {
+    var coordinator = Self.initWithSettleInterval(testing.allocator, 100);
+    defer coordinator.deinit();
+
+    _ = try coordinator.recordAccepted(10, fullscreen, .layout, 1_000);
+    try testing.expectEqual(
+        ObservationOwner.manager,
+        try coordinator.observe(10, tiled, 1_050, 20),
+    );
+    try testing.expectEqual(
+        ObservationOwner.user,
+        try coordinator.observe(10, tiled, 1_051, 10),
+    );
+    try testing.expect(coordinator.get(10).?.intent == null);
+}
+
+test "new accepted write supersedes the prior generation" {
+    var coordinator = Self.initWithSettleInterval(testing.allocator, 100);
+    defer coordinator.deinit();
+
+    const first = try coordinator.recordAccepted(10, fullscreen, .layout, 1_000);
+    const second = try coordinator.recordAccepted(10, tiled, .layout, 1_010);
+    try testing.expectEqual(first.generation + 1, second.generation);
+    try testing.expect(coordinator.get(10).?.intent.?.target.approxEqual(tiled, Frame.tolerance));
+}
+
+test "clearIntents preserves physical observations" {
+    var coordinator = Self.initWithSettleInterval(testing.allocator, 100);
+    defer coordinator.deinit();
+
+    _ = try coordinator.recordAccepted(10, fullscreen, .layout, 1_000);
+    _ = try coordinator.observe(10, fullscreen, 1_001, null);
+    coordinator.clearIntents();
+
+    const entry = coordinator.get(10).?;
+    try testing.expect(entry.intent == null);
+    try testing.expect(entry.observed.?.approxEqual(fullscreen, Frame.tolerance));
+}
+
+test "forget removes all window geometry state" {
+    var coordinator = Self.init(testing.allocator);
+    defer coordinator.deinit();
+
+    _ = try coordinator.recordAccepted(10, fullscreen, .layout, 1_000);
+    coordinator.forget(10);
+    try testing.expect(coordinator.get(10) == null);
+}

--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const posix = std.posix;
 const tiling = @import("tiling.zig");
 const osutil = @import("osutil.zig");
+const runtime_paths = @import("runtime_paths.zig");
 
 const log = std.log.scoped(.ipc);
 
@@ -149,7 +150,8 @@ pub const Server = struct {
     path: [:0]const u8,
 
     pub fn init(allocator: std.mem.Allocator) !Server {
-        const path = try std.fmt.allocPrintSentinel(allocator, "/tmp/bobrwm_{d}.sock", .{std.c.getuid()}, 0);
+        try runtime_paths.ensureRuntimeDir(allocator);
+        const path = try runtime_paths.socketPathAlloc(allocator);
         errdefer allocator.free(path);
 
         // Check if another daemon is already running by probing the socket.
@@ -164,8 +166,9 @@ pub const Server = struct {
             defer _ = std.c.close(probe_fd);
 
             var addr: posix.sockaddr.un = .{ .path = undefined, .family = posix.AF.UNIX };
+            if (path.len >= addr.path.len) return error.NameTooLong;
             @memcpy(addr.path[0..path.len], path[0..path.len]);
-            if (path.len < addr.path.len) addr.path[path.len] = 0;
+            addr.path[path.len] = 0;
 
             if (std.c.connect(probe_fd, @ptrCast(&addr), @sizeOf(posix.sockaddr.un)) == 0) {
                 log.err("another bobrwm instance is already running on {s}", .{path});
@@ -183,13 +186,12 @@ pub const Server = struct {
         disableSigpipe(fd);
 
         var addr: posix.sockaddr.un = .{ .path = undefined, .family = posix.AF.UNIX };
-        if (path.len > addr.path.len) return error.NameTooLong;
+        if (path.len >= addr.path.len) return error.NameTooLong;
         @memcpy(addr.path[0..path.len], path[0..path.len]);
-        if (path.len < addr.path.len) {
-            addr.path[path.len] = 0;
-        }
+        addr.path[path.len] = 0;
 
         if (std.c.bind(fd, @ptrCast(&addr), @sizeOf(posix.sockaddr.un)) != 0) return error.BindFailed;
+        if (std.c.chmod(path, 0o600) != 0) return error.SecureSocketFailed;
         if (std.c.listen(fd, 5) != 0) return error.ListenFailed;
 
         log.info("IPC listening on {s}", .{path});

--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -156,7 +156,6 @@ pub const Server = struct {
     path: [:0]const u8,
 
     pub fn init(allocator: std.mem.Allocator) !Server {
-        try runtime_paths.ensureRuntimeDir(allocator);
         const path = try runtime_paths.socketPathAlloc(allocator);
         errdefer allocator.free(path);
 

--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const posix = std.posix;
 const tiling = @import("tiling.zig");
+const workspace = @import("workspace.zig");
 const osutil = @import("osutil.zig");
 const runtime_paths = @import("runtime_paths.zig");
 
@@ -72,9 +73,9 @@ pub const IpcCommand = union(enum) {
         if (stripPrefix(cmd, "focus-workspace ")) |arg|
             return parseWorkspaceTarget(arg);
         if (stripPrefix(cmd, "move-to-workspace ")) |arg|
-            return parseU8(arg, .move_to_workspace);
+            return parseBoundedU8(arg, workspace.max_workspaces, .move_to_workspace);
         if (stripPrefix(cmd, "move-to-display ")) |arg|
-            return parseU8(arg, .move_to_display);
+            return parseBoundedU8(arg, workspace.max_displays, .move_to_display);
         if (stripPrefix(cmd, "move-workspace-to-display ")) |arg|
             return parseDisplayTarget(arg);
         if (stripPrefix(cmd, "bsp ratio rel ")) |arg|
@@ -103,8 +104,9 @@ pub const IpcCommand = union(enum) {
         return @unionInit(IpcCommand, @tagName(tag), val);
     }
 
-    fn parseU8(arg: []const u8, comptime tag: anytype) ?IpcCommand {
+    fn parseBoundedU8(arg: []const u8, comptime max: u8, comptime tag: anytype) ?IpcCommand {
         const val = std.fmt.parseInt(u8, arg, 10) catch return null;
+        if (val == 0 or val > max) return null;
         return @unionInit(IpcCommand, @tagName(tag), val);
     }
 
@@ -115,6 +117,8 @@ pub const IpcCommand = union(enum) {
 
     fn parseFloat(arg: []const u8, comptime tag: anytype) ?IpcCommand {
         const val = std.fmt.parseFloat(f64, arg) catch return null;
+        if (!std.math.isFinite(val)) return null;
+        if (tag == .bsp_ratio_abs and (val < 0.1 or val > 0.9)) return null;
         return @unionInit(IpcCommand, @tagName(tag), val);
     }
 
@@ -124,6 +128,7 @@ pub const IpcCommand = union(enum) {
         if (std.mem.eql(u8, arg, "next"))
             return .{ .focus_workspace = .next };
         const n = std.fmt.parseInt(u8, arg, 10) catch return null;
+        if (n == 0 or n > workspace.max_workspaces) return null;
         return .{ .focus_workspace = .{ .index = n } };
     }
 
@@ -133,6 +138,7 @@ pub const IpcCommand = union(enum) {
         if (std.mem.eql(u8, arg, "prev"))
             return .{ .move_workspace_to_display = .prev };
         const n = std.fmt.parseInt(u8, arg, 10) catch return null;
+        if (n == 0 or n > workspace.max_displays) return null;
         return .{ .move_workspace_to_display = .{ .index = n } };
     }
 };
@@ -284,4 +290,20 @@ test "parse focus workspace target" {
     try t.expectEqual(IpcCommand{ .focus_workspace = .prev }, IpcCommand.parse("focus-workspace prev").?);
     try t.expectEqual(IpcCommand{ .focus_workspace = .next }, IpcCommand.parse("focus-workspace next").?);
     try t.expectEqual(@as(?IpcCommand, null), IpcCommand.parse("focus-workspace previous"));
+    try t.expectEqual(@as(?IpcCommand, null), IpcCommand.parse("focus-workspace 0"));
+}
+
+test "parse rejects invalid numeric command arguments" {
+    const t = std.testing;
+
+    try t.expectEqual(@as(?IpcCommand, null), IpcCommand.parse("move-to-workspace 0"));
+    try t.expectEqual(@as(?IpcCommand, null), IpcCommand.parse("move-to-workspace 11"));
+    try t.expectEqual(@as(?IpcCommand, null), IpcCommand.parse("move-to-display 0"));
+    try t.expectEqual(@as(?IpcCommand, null), IpcCommand.parse("move-to-display 9"));
+    try t.expectEqual(@as(?IpcCommand, null), IpcCommand.parse("move-workspace-to-display 0"));
+    try t.expectEqual(@as(?IpcCommand, null), IpcCommand.parse("move-workspace-to-display 9"));
+    try t.expectEqual(@as(?IpcCommand, null), IpcCommand.parse("bsp ratio rel nan"));
+    try t.expectEqual(@as(?IpcCommand, null), IpcCommand.parse("bsp ratio abs 0"));
+    try t.expectEqual(@as(?IpcCommand, null), IpcCommand.parse("bsp ratio abs 1"));
+    try t.expectEqual(IpcCommand{ .bsp_ratio_abs = 0.5 }, IpcCommand.parse("bsp ratio abs 0.5").?);
 }

--- a/src/ipc_transport.zig
+++ b/src/ipc_transport.zig
@@ -1,0 +1,138 @@
+//! Background IPC socket accept/read transport.
+//!
+//! The transport owns client sockets until the main thread pops a complete
+//! request. Parsing and state mutation deliberately remain outside this module.
+
+const std = @import("std");
+const posix = std.posix;
+
+const ipc = @import("ipc.zig");
+const spsc_queue = @import("spsc_queue.zig");
+
+const log = std.log.scoped(.ipc_transport);
+
+pub const Request = struct {
+    fd: posix.socket_t,
+    len: u16,
+    buf: [512]u8,
+
+    /// Return the trimmed command bytes read from the client.
+    pub fn command(self: *const Request) []const u8 {
+        return self.buf[0..self.len];
+    }
+};
+
+const RequestQueue = spsc_queue.Queue(Request, 16);
+const WakeFn = *const fn () void;
+
+pub const Transport = struct {
+    const Self = @This();
+
+    queue: RequestQueue = .{},
+    thread: ?std.Thread = null,
+    stop_requested: std.atomic.Value(bool) = .init(false),
+    listener_fd: posix.socket_t = -1,
+    wake: ?WakeFn = null,
+
+    /// Start accepting requests from an already-listening Unix socket.
+    pub fn start(self: *Self, listener_fd: posix.socket_t, wake: WakeFn) !void {
+        std.debug.assert(self.thread == null);
+        std.debug.assert(listener_fd >= 0);
+
+        self.listener_fd = listener_fd;
+        self.wake = wake;
+        self.stop_requested.store(false, .release);
+        self.thread = std.Thread.spawn(.{}, acceptLoop, .{self}) catch |err| {
+            self.listener_fd = -1;
+            self.wake = null;
+            return err;
+        };
+    }
+
+    /// Stop the acceptor and close any client sockets not yet consumed.
+    pub fn stop(self: *Self) void {
+        self.stop_requested.store(true, .release);
+        if (self.thread) |thread| thread.join();
+        self.thread = null;
+
+        while (self.queue.pop()) |request| {
+            _ = std.c.close(request.fd);
+        }
+        self.listener_fd = -1;
+        self.wake = null;
+    }
+
+    /// Transfer ownership of the oldest complete request to the caller.
+    pub fn pop(self: *Self) ?Request {
+        return self.queue.pop();
+    }
+
+    fn acceptLoop(self: *Self) void {
+        while (!self.stop_requested.load(.acquire)) {
+            var poll_fds = [_]posix.pollfd{.{
+                .fd = self.listener_fd,
+                .events = posix.POLL.IN,
+                .revents = 0,
+            }};
+            const ready = posix.poll(&poll_fds, 250) catch |err| {
+                if (!self.stop_requested.load(.acquire)) {
+                    log.warn("IPC listener poll failed: {}", .{err});
+                }
+                continue;
+            };
+            if (ready == 0) continue;
+
+            const client_fd = std.c.accept(self.listener_fd, null, null);
+            if (client_fd < 0) continue;
+            configureClient(client_fd);
+
+            const request = readRequest(client_fd) orelse {
+                _ = std.c.close(client_fd);
+                continue;
+            };
+            if (!self.queue.push(request)) {
+                ipc.writeResponse(client_fd, "err: IPC queue busy\n");
+                _ = std.c.close(client_fd);
+                continue;
+            }
+            self.wake.?();
+        }
+    }
+};
+
+fn configureClient(fd: posix.socket_t) void {
+    ipc.disableSigpipe(fd);
+    const timeout: std.c.timeval = .{ .sec = 0, .usec = 250_000 };
+    posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.SNDTIMEO, std.mem.asBytes(&timeout)) catch |err| {
+        log.warn("IPC send timeout setup failed: {}", .{err});
+    };
+}
+
+fn readRequest(fd: posix.socket_t) ?Request {
+    var request: Request = .{ .fd = fd, .len = 0, .buf = undefined };
+    var written: usize = 0;
+
+    while (written < request.buf.len) {
+        var poll_fds = [_]posix.pollfd{.{
+            .fd = fd,
+            .events = posix.POLL.IN,
+            .revents = 0,
+        }};
+        const ready = posix.poll(&poll_fds, 1000) catch return null;
+        if (ready == 0) return null;
+
+        const n = posix.read(fd, request.buf[written..]) catch return null;
+        if (n == 0) break;
+        written += n;
+    }
+
+    if (written == request.buf.len) {
+        ipc.writeResponse(fd, "err: command too long\n");
+        return null;
+    }
+
+    const command = std.mem.trimEnd(u8, request.buf[0..written], &.{ '\n', '\r', ' ', 0 });
+    if (command.len == 0) return null;
+    request.len = @intCast(command.len);
+    return request;
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -3007,10 +3007,16 @@ fn windowIsTiled(wid: u32) bool {
     return win.mode == .tiled;
 }
 
-fn insertIntoTiling(workspace_id: u8, wid: u32) void {
+fn tryInsertIntoTiling(workspace_id: u8, wid: u32) !void {
     const sp = tilingStatePtr(workspace_id);
-    if (sp.* == null) sp.* = tiling.newState(g_config.layout);
-    const ws = g_workspaces.get(workspace_id) orelse return;
+    const created_state = sp.* == null;
+    if (created_state) sp.* = tiling.newState(g_config.layout);
+    errdefer if (created_state) {
+        sp.*.?.deinit(g_allocator);
+        sp.* = null;
+    };
+
+    const ws = g_workspaces.get(workspace_id) orelse return error.InvalidWorkspace;
     const anchor_wid = blk: {
         const st = sp.* orelse break :blk null;
         switch (g_config.bsp_insert_point) {
@@ -3032,7 +3038,26 @@ fn insertIntoTiling(workspace_id: u8, wid: u32) void {
         .inner_gap = @floatFromInt(g_config.gaps.inner),
         .split_ratio = g_config.bsp_split_ratio,
     };
-    sp.*.?.insert(wid, options, g_allocator) catch return;
+    try sp.*.?.insert(wid, options, g_allocator);
+}
+
+fn insertIntoTiling(workspace_id: u8, wid: u32) void {
+    tryInsertIntoTiling(workspace_id, wid) catch |err| {
+        log.err("failed to insert wid={d} into workspace {d} layout: {}", .{ wid, workspace_id, err });
+    };
+}
+
+/// Reserve every allocating container before committing a managed window.
+/// Layout insertion happens before the no-fail store/workspace append, so an
+/// allocation failure cannot leave a window present in only part of the model.
+fn adoptWindow(ws: *workspace_mod.Workspace, win: window_mod.Window) !void {
+    std.debug.assert(g_store.get(win.wid) == null);
+    try g_store.ensureUnusedCapacity(1);
+    try ws.ensureUnusedWindowCapacity(1);
+    if (win.mode == .tiled) try tryInsertIntoTiling(ws.id, win.wid);
+
+    g_store.putAssumeCapacity(win);
+    ws.addWindowAssumeCapacity(win.wid);
 }
 
 fn setTilingActive(workspace_id: u8, wid: u32) void {
@@ -3618,18 +3643,22 @@ fn setWindowMode(wid: u32, target: window_mod.WindowMode) void {
     const old = win.mode;
     if (old == target) return;
 
+    // Allocate the new layout slot before changing the stored mode. On
+    // failure the window remains consistently floating.
+    if (target == .tiled) {
+        tryInsertIntoTiling(win.workspace_id, wid) catch |err| {
+            log.err("failed to tile wid={d}: {}", .{ wid, err });
+            return;
+        };
+    }
+
     // Leaving tiled → remove from BSP so remaining windows fill the space
     if (old == .tiled) {
         removeFromTiling(win.workspace_id, wid);
     }
 
-    // Entering tiled → re-insert into BSP
-    if (target == .tiled) {
-        insertIntoTiling(win.workspace_id, wid);
-    }
-
     win.mode = target;
-    g_store.put(win) catch {};
+    g_store.putAssumeCapacity(win);
     log.info("window {d} mode: {s} → {s}", .{ wid, @tagName(old), @tagName(target) });
     retile();
 }
@@ -4340,9 +4369,10 @@ fn discoverWindows() void {
             .display_id = managed_display,
         };
 
-        g_store.put(win) catch continue;
-        target_ws.addWindow(info.wid) catch continue;
-        insertIntoTiling(target_ws.id, info.wid);
+        adoptWindow(target_ws, win) catch |err| {
+            log.err("discover: failed to adopt pid={d} wid={d}: {}", .{ info.pid, info.wid, err });
+            continue;
+        };
 
         // If assigned to a non-visible workspace, hide immediately
         if (!workspaceVisibleOnDisplay(target_ws.id, managed_display)) {
@@ -4550,11 +4580,10 @@ fn addNewWindowManagedWithAssignment(pid: i32, wid: u32, workspace_id: u8, assig
         .display_id = display_id,
     };
 
-    g_store.put(win) catch return false;
-    ws.addWindow(wid) catch return false;
-    if (mode == .tiled) {
-        insertIntoTiling(ws.id, wid);
-    }
+    adoptWindow(ws, win) catch |err| {
+        log.err("addNewWindow: failed to adopt pid={d} wid={d}: {}", .{ pid, wid, err });
+        return false;
+    };
     ws.recordFocus(wid);
 
     // If assigned to a non-visible workspace, hide immediately
@@ -4661,8 +4690,9 @@ fn refreshTabGroupActiveTabs() void {
         // The user can select a tab Bobrwm has never seen: background tabs are
         // absent from AXWindows, so they are only discovered as they surface.
         if (g_store.get(move.selected) == null) {
+            g_store.ensureUnusedCapacity(1) catch continue;
             g_tab_groups.addMember(move.group_id, move.selected) catch continue;
-            g_store.put(.{
+            g_store.putAssumeCapacity(.{
                 .wid = move.selected,
                 .pid = group.pid,
                 .title = null,
@@ -4671,7 +4701,7 @@ fn refreshTabGroupActiveTabs() void {
                 .mode = leader.mode,
                 .workspace_id = leader.workspace_id,
                 .display_id = leader.display_id,
-            }) catch continue;
+            });
         }
 
         log.debug("tab group {d} active tab {d} → {d} (tab bar)", .{
@@ -4731,16 +4761,21 @@ fn tryFormTabGroupOnCreate(pid: i32, new_wid: u32) bool {
 fn joinTabGroup(pid: i32, sibling_wid: u32, new_wid: u32, new_frame: window_mod.Window.Frame) bool {
     const sibling = g_store.get(sibling_wid) orelse return false;
     const ws = g_workspaces.get(sibling.workspace_id) orelse return false;
+    std.debug.assert(g_store.get(new_wid) == null);
 
-    const group_id = if (g_tab_groups.groupOf(sibling_wid)) |g|
-        g.id
-    else
-        g_tab_groups.createGroup(pid, sibling_wid, sibling.frame) catch return false;
+    // Reserve the store first. Once the group mutation succeeds, publishing
+    // the new member's Window record cannot fail.
+    g_store.ensureUnusedCapacity(1) catch return false;
 
-    g_tab_groups.addMember(group_id, new_wid) catch return false;
+    if (g_tab_groups.groupOf(sibling_wid)) |g| {
+        g_tab_groups.addMember(g.id, new_wid) catch return false;
+    } else {
+        _ = g_tab_groups.createGroupWithMember(pid, sibling_wid, new_wid, sibling.frame) catch return false;
+    }
+
     g_tab_groups.setActive(new_wid);
 
-    g_store.put(.{
+    g_store.putAssumeCapacity(.{
         .wid = new_wid,
         .pid = pid,
         .title = null,
@@ -4749,7 +4784,7 @@ fn joinTabGroup(pid: i32, sibling_wid: u32, new_wid: u32, new_frame: window_mod.
         .mode = sibling.mode,
         .workspace_id = sibling.workspace_id,
         .display_id = sibling.display_id,
-    }) catch return false;
+    });
 
     const leader = g_tab_groups.resolveLeader(sibling_wid);
     ws.recordFocus(leader);
@@ -5117,11 +5152,11 @@ fn adoptWindowAsBackgroundTab(win: window_mod.Window) tabgroup.detect.OffscreenO
 
     const sibling = g_store.get(sibling_wid) orelse return .reap;
 
-    const group_id = if (g_tab_groups.groupOf(sibling_wid)) |g|
-        g.id
-    else
-        g_tab_groups.createGroup(win.pid, sibling_wid, sibling.frame) catch return .reap;
-    g_tab_groups.addMember(group_id, win.wid) catch return .reap;
+    if (g_tab_groups.groupOf(sibling_wid)) |group| {
+        g_tab_groups.addMember(group.id, win.wid) catch return .reap;
+    } else {
+        _ = g_tab_groups.createGroupWithMember(win.pid, sibling_wid, win.wid, sibling.frame) catch return .reap;
+    }
     g_tab_groups.setActive(sibling_wid);
 
     // Members live only in the store; drop the standalone workspace/layout slot.
@@ -6044,18 +6079,21 @@ fn moveWindowToWorkspace(target_id: u8) void {
     const wid = wid_opt orelse return;
     if (target_id == ws.id) return;
     const target_ws = g_workspaces.get(target_id) orelse return;
-
-    // Remove from current workspace BSP + list
-    ws.removeWindow(wid);
-    removeFromTiling(ws.id, wid);
-
     var updated = g_store.get(wid) orelse return;
 
-    // Add to target workspace BSP + list
-    target_ws.addWindow(wid) catch return;
+    // Prepare the destination completely before removing the source slot.
+    // After these fallible steps, the move commits without allocation.
+    target_ws.ensureUnusedWindowCapacity(1) catch return;
     if (updated.mode == .tiled) {
-        insertIntoTiling(target_id, wid);
+        tryInsertIntoTiling(target_id, wid) catch |err| {
+            log.err("failed to move wid={d} to workspace {d}: {}", .{ wid, target_id, err });
+            return;
+        };
     }
+    target_ws.addWindowAssumeCapacity(wid);
+
+    ws.removeWindow(wid);
+    removeFromTiling(ws.id, wid);
     if (target_ws.focused_wid == null) {
         target_ws.recordFocus(wid);
     }
@@ -6067,7 +6105,7 @@ fn moveWindowToWorkspace(target_id: u8) void {
     // switchWorkspace will correct it when the workspace is activated.
     updated.workspace_id = target_id;
     updated.display_id = target_ws.display_id orelse display_id;
-    g_store.put(updated) catch {};
+    g_store.putAssumeCapacity(updated);
     updateTabGroupAssignment(wid, target_id, updated.display_id);
 
     // If target is not visible on the window's new display, hide it.
@@ -6098,43 +6136,37 @@ fn moveManagedWindowToDisplay(wid: u32, target_display_id: u32) bool {
         const source_ws = g_workspaces.get(source_workspace_id) orelse return false;
         const target_ws = g_workspaces.get(target_workspace_id) orelse return false;
 
-        var target_had_window = false;
         for (target_ws.windows.items) |existing_wid| {
             if (existing_wid == wid) {
-                target_had_window = true;
-                break;
+                log.warn("refusing display move for wid={d}: already in target workspace {d}", .{ wid, target_workspace_id });
+                return false;
             }
         }
 
-        target_ws.addWindow(wid) catch return false;
+        target_ws.ensureUnusedWindowCapacity(1) catch return false;
+        if (win.mode == .tiled) {
+            tryInsertIntoTiling(target_workspace_id, wid) catch |err| {
+                log.err("failed to move wid={d} to display {d}: {}", .{ wid, target_display_id, err });
+                return false;
+            };
+        }
+        target_ws.addWindowAssumeCapacity(wid);
 
         var updated = win;
         updated.workspace_id = target_workspace_id;
         updated.display_id = target_display_id;
-        g_store.put(updated) catch {
-            if (!target_had_window) {
-                target_ws.removeWindow(wid);
-            }
-            return false;
-        };
+        g_store.putAssumeCapacity(updated);
         updateTabGroupAssignment(wid, target_workspace_id, target_display_id);
 
         removeFromTiling(source_workspace_id, wid);
         source_ws.removeWindow(wid);
         target_ws.recordFocus(wid);
-        if (updated.mode == .tiled) {
-            insertIntoTiling(target_workspace_id, wid);
-        }
 
         win = updated;
     } else {
-        removeFromTiling(source_workspace_id, wid);
         win.display_id = target_display_id;
-        g_store.put(win) catch return false;
+        g_store.putAssumeCapacity(win);
         updateTabGroupAssignment(wid, source_workspace_id, target_display_id);
-        if (win.mode == .tiled) {
-            insertIntoTiling(source_workspace_id, wid);
-        }
     }
 
     _ = maybeSetFocusedDisplayForWindow(win, .keyboard);

--- a/src/main.zig
+++ b/src/main.zig
@@ -95,6 +95,12 @@ const workspace_event_debounce_interval_s: f64 = 0.05;
 const display_settle_delay_s: f64 = 0.25;
 /// Hard cap for workspace transition convergence before we fail closed.
 const workspace_transition_watchdog_interval_s: f64 = 0.4;
+/// A successful AX write can precede the corresponding WindowServer move.
+/// Keep the outgoing workspace covering the display while polling for the
+/// incoming physical frames; the deferred path handles slower applications.
+const workspace_reveal_poll_interval_us: u32 = 500;
+const workspace_reveal_wait_max_us: u32 = 50_000;
+const workspace_reveal_deferred_timeout_s: f64 = 1.0;
 
 const DisplayInfo = struct {
     id: u32,
@@ -170,6 +176,13 @@ const WorkspaceTransitionState = struct {
     fn isActive(self: WorkspaceTransitionState) bool {
         return self.kind != .idle;
     }
+};
+
+const PendingWorkspacePark = struct {
+    outgoing_workspace_id: u8,
+    target_workspace_id: u8,
+    display_id: u32,
+    deadline_at_s: f64,
 };
 
 const PendingFocusEntry = struct {
@@ -1536,6 +1549,7 @@ var g_role_poll_source: c.dispatch_source_t = null;
 var g_tap_port: c.CFMachPortRef = null;
 var g_workspace_transition: WorkspaceTransitionState = .{};
 var g_workspace_transition_completion_reason: WorkspaceTransitionCompletionReason = .none;
+var g_pending_workspace_parks: [workspace_mod.max_displays]?PendingWorkspacePark = @splat(null);
 var g_pending_focus_entries: [pending_focus_capacity_per_epoch]PendingFocusEntry = undefined;
 var g_pending_focus_count: usize = 0;
 var g_pending_focus_sequence: u64 = 0;
@@ -3618,6 +3632,7 @@ fn handleEvent(ev: *const event_mod.Event) void {
         },
         .role_poll_tick => {
             reconcileDueGeometryObservations();
+            processPendingWorkspaceParks();
             if (processDueDisplayResettle()) return;
             const promoted_pending = processPendingRoleWindows();
             const promoted_deferred = processDeferredWindowCandidates();
@@ -3910,6 +3925,7 @@ fn refreshRolePolling() void {
         g_focus_retries.count() > 0 or
         g_deferred_follow_focus != null or
         g_display_resettle_at_s != 0 or
+        hasPendingWorkspaceParks() or
         g_event_overflow_recovery_pending or
         g_geometry.hasPendingResamples();
     setRolePolling(has_pending);
@@ -5528,6 +5544,11 @@ fn firstUnclaimedWorkspace(claimed: []const bool) u8 {
 /// windows always follow their workspace — to the primary display when their
 /// monitor vanished, and back when it returns and reclaims the workspace.
 fn reconcileDisplayChange() void {
+    // Display slots and ids are about to be rebuilt. Any delayed park keyed
+    // by the old topology is invalid; parkHiddenWorkspaceWindows below
+    // re-establishes visibility from the new authoritative mapping.
+    g_pending_workspace_parks = @splat(null);
+
     // Snapshot present displays' active workspaces (by UUID) before the
     // topology changes, so a monitor that vanishes keeps its binding and
     // reclaims its workspace on return.
@@ -5611,6 +5632,7 @@ fn reconcileDisplayChange() void {
     parkHiddenWorkspaceWindows();
     rememberDisplayWorkspaces();
     assertDisplayCoverage();
+    refreshRolePolling();
 }
 
 /// Park every window of every hidden workspace so a topology change never
@@ -6140,6 +6162,147 @@ fn resolveWorkspace(pid: i32, display_id: u32) *workspace_mod.Workspace {
 
 // Workspace switching
 
+fn frameCenterOnDisplay(frame: window_mod.Window.Frame, display: shim.bw_frame) bool {
+    if (frame.width <= 0 or frame.height <= 0) return false;
+    const center_x = frame.x + frame.width / 2.0;
+    const center_y = frame.y + frame.height / 2.0;
+    return center_x >= display.x and center_x <= display.x + display.w and
+        center_y >= display.y and center_y <= display.y + display.h;
+}
+
+/// Confirm that every non-minimized incoming window physically covers its
+/// assigned target. AX returning success only means the app accepted the
+/// request; WindowServer can expose the parked frame for several more
+/// milliseconds. An empty workspace is immediately ready because revealing
+/// the wallpaper is the requested result.
+fn workspaceRevealSettled(ws: *const workspace_mod.Workspace, display_id: u32) bool {
+    const display_slot = displayIndexById(display_id) orelse return false;
+    const display = g_displays[display_slot].visible;
+
+    for (ws.windows.items) |leader_wid| {
+        const visible_wid = g_tab_groups.resolveActive(leader_wid);
+        const win = g_store.get(visible_wid) orelse return false;
+        if (win.is_minimized) continue;
+        if (win.workspace_id != ws.id or win.display_id != display_id) return false;
+        if (!frameCenterOnDisplay(win.frame, display)) return false;
+
+        const actual = liveWindowFrame(visible_wid) orelse return false;
+        if (!workspace_mod.frameCoversTarget(actual, win.frame)) return false;
+    }
+    return true;
+}
+
+fn waitForWorkspaceReveal(ws: *const workspace_mod.Workspace, display_id: u32) bool {
+    var waited_us: u32 = 0;
+    while (waited_us < workspace_reveal_wait_max_us) : (waited_us += workspace_reveal_poll_interval_us) {
+        if (workspaceRevealSettled(ws, display_id)) return true;
+        _ = c.usleep(workspace_reveal_poll_interval_us);
+    }
+    return workspaceRevealSettled(ws, display_id);
+}
+
+/// Park immediately once the incoming pixels are visible. Slow AX servers use
+/// the role-poll path, which leaves the old workspace covering the display
+/// instead of exposing the wallpaper while the reveal is still in flight.
+fn parkOutgoingWhenRevealed(
+    outgoing_ws: *workspace_mod.Workspace,
+    target_ws: *const workspace_mod.Workspace,
+    display_id: u32,
+) void {
+    const display_slot = displayIndexById(display_id) orelse return;
+    const prior = g_pending_workspace_parks[display_slot];
+
+    if (waitForWorkspaceReveal(target_ws, display_id)) {
+        g_pending_workspace_parks[display_slot] = null;
+        parkOutgoingWorkspace(outgoing_ws, target_ws.id, display_id);
+        if (prior) |pending| {
+            if (pending.outgoing_workspace_id != outgoing_ws.id and
+                pending.outgoing_workspace_id != target_ws.id)
+            {
+                if (g_workspaces.get(pending.outgoing_workspace_id)) |prior_outgoing| {
+                    parkOutgoingWorkspace(prior_outgoing, target_ws.id, display_id);
+                }
+            }
+        }
+        refreshRolePolling();
+        return;
+    }
+
+    // A prior deferred outgoing workspace still covers this display. Keep it
+    // as the cover and park the logical current workspace now, otherwise a
+    // rapid A → B → C sequence would leak both A and B over C.
+    const cover_workspace_id: u8 = if (prior) |pending| blk: {
+        if (pending.outgoing_workspace_id != target_ws.id and
+            pending.outgoing_workspace_id != outgoing_ws.id)
+        {
+            parkOutgoingWorkspace(outgoing_ws, target_ws.id, display_id);
+            break :blk pending.outgoing_workspace_id;
+        }
+        break :blk outgoing_ws.id;
+    } else outgoing_ws.id;
+
+    g_pending_workspace_parks[display_slot] = .{
+        .outgoing_workspace_id = cover_workspace_id,
+        .target_workspace_id = target_ws.id,
+        .display_id = display_id,
+        .deadline_at_s = c.CFAbsoluteTimeGetCurrent() + workspace_reveal_deferred_timeout_s,
+    };
+    log.debug("workspace switch deferring outgoing park current_workspace={d} target_workspace={d} display={d}", .{
+        cover_workspace_id,
+        target_ws.id,
+        display_id,
+    });
+    refreshRolePolling();
+}
+
+fn hasPendingWorkspaceParks() bool {
+    for (g_pending_workspace_parks) |pending| {
+        if (pending != null) return true;
+    }
+    return false;
+}
+
+fn processPendingWorkspaceParks() void {
+    var changed = false;
+    for (0..g_display_count) |display_slot| {
+        const pending = g_pending_workspace_parks[display_slot] orelse continue;
+        const active_workspace_id = g_workspaces.activeIdForDisplaySlot(display_slot);
+        if (active_workspace_id != pending.target_workspace_id) {
+            g_pending_workspace_parks[display_slot] = null;
+            changed = true;
+            if (pending.outgoing_workspace_id != active_workspace_id) {
+                if (g_workspaces.get(pending.outgoing_workspace_id)) |outgoing_ws| {
+                    parkOutgoingWorkspace(outgoing_ws, active_workspace_id, pending.display_id);
+                }
+            }
+            continue;
+        }
+
+        const target_ws = g_workspaces.get(pending.target_workspace_id) orelse {
+            g_pending_workspace_parks[display_slot] = null;
+            changed = true;
+            continue;
+        };
+        const reveal_settled = workspaceRevealSettled(target_ws, pending.display_id);
+        const timed_out = c.CFAbsoluteTimeGetCurrent() >= pending.deadline_at_s;
+        if (!reveal_settled and !timed_out) continue;
+
+        g_pending_workspace_parks[display_slot] = null;
+        changed = true;
+        if (!reveal_settled) {
+            log.warn("workspace switch reveal timed out current_workspace={d} target_workspace={d} display={d}; parking outgoing workspace", .{
+                pending.outgoing_workspace_id,
+                pending.target_workspace_id,
+                pending.display_id,
+            });
+        }
+        if (g_workspaces.get(pending.outgoing_workspace_id)) |outgoing_ws| {
+            parkOutgoingWorkspace(outgoing_ws, pending.target_workspace_id, pending.display_id);
+        }
+    }
+    if (changed) refreshRolePolling();
+}
+
 fn switchWorkspace(target_id: u8) void {
     const target_ws = g_workspaces.get(target_id) orelse return;
 
@@ -6201,12 +6364,17 @@ fn switchWorkspace(target_id: u8) void {
 
     startWorkspaceTransition(.switch_workspace, target_id, target_display);
     retile();
+    // `retile` normally batches work until the event drain completes. A
+    // workspace switch cannot use that latency boundary: parking the outgoing
+    // windows before the incoming AX writes land exposes the wallpaper. Flush
+    // the reveal now, while the outgoing workspace still covers the display.
+    flushRetileRequests();
     setFocusedDisplay(target_display);
     updateStatusBar();
 
     focusWorkspaceWindow(target_ws);
 
-    parkOutgoingWorkspace(old_ws, target_id, target_display);
+    parkOutgoingWhenRevealed(old_ws, target_ws, target_display);
 }
 
 /// Park every window the outgoing workspace has on `display_id`.

--- a/src/main.zig
+++ b/src/main.zig
@@ -91,6 +91,39 @@ const EventRing = struct {
     }
 };
 
+const IpcRequest = struct {
+    fd: c_int,
+    len: u16,
+    buf: [512]u8,
+};
+
+/// One IPC acceptor thread produces complete requests; the main thread drains
+/// them. Socket reads never run on AppKit's queue.
+const IpcRequestRing = struct {
+    const capacity = 16;
+
+    buf: [capacity]IpcRequest = undefined,
+    head: std.atomic.Value(usize) = .init(0),
+    tail: std.atomic.Value(usize) = .init(0),
+
+    fn push(self: *IpcRequestRing, request: IpcRequest) bool {
+        const tail = self.tail.load(.monotonic);
+        const next = (tail + 1) % capacity;
+        if (next == self.head.load(.acquire)) return false;
+        self.buf[tail] = request;
+        self.tail.store(next, .release);
+        return true;
+    }
+
+    fn pop(self: *IpcRequestRing) ?IpcRequest {
+        const head = self.head.load(.monotonic);
+        if (head == self.tail.load(.acquire)) return null;
+        const request = self.buf[head];
+        self.head.store((head + 1) % capacity, .release);
+        return request;
+    }
+};
+
 // Hidden-window position (bottom-right corner, barely visible)
 
 /// Pixels visible in the corner when a window is hidden off-screen.
@@ -1525,7 +1558,6 @@ var g_display_resettle_at_s: f64 = 0;
 var g_hotkey_bindings: []const shim.bw_keybind = &.{};
 var g_waker_source: c.CFRunLoopSourceRef = null;
 var g_role_poll_source: c.dispatch_source_t = null;
-var g_ipc_source: c.dispatch_source_t = null;
 var g_tap_port: c.CFMachPortRef = null;
 var g_workspace_transition: WorkspaceTransitionState = .{};
 var g_workspace_transition_completion_reason: WorkspaceTransitionCompletionReason = .none;
@@ -1544,6 +1576,9 @@ var g_cleanup_pending_pid_count: usize = 0;
 
 var g_animator: animation_mod.Animator = undefined;
 var g_animator_source: c.dispatch_source_t = null;
+var g_ipc_requests: IpcRequestRing = .{};
+var g_ipc_thread: ?std.Thread = null;
+var g_ipc_transport_stop: std.atomic.Value(bool) = .init(false);
 
 const ConfigRuntime = struct {
     arena: std.heap.ArenaAllocator,
@@ -2460,39 +2495,6 @@ fn setupHotkeyEventTap() void {
     cg_extra.CGEventTapEnable(tap, true);
 }
 
-fn ipcSourceTick(context: ?*anyopaque) callconv(.c) void {
-    const fd_raw = @intFromPtr(context orelse return);
-    const server_fd: c_int = @intCast(fd_raw);
-    bw_handle_ipc_client(server_fd);
-}
-
-fn initIpcSource(server_fd: c_int) void {
-    if (g_ipc_source) |source| {
-        c.dispatch_source_cancel(source);
-        g_ipc_source = null;
-    }
-
-    const source = c.dispatch_source_create(
-        cg_extra.DISPATCH_SOURCE_TYPE_READ(),
-        @intCast(server_fd),
-        0,
-        cg_extra.dispatch_get_main_queue(),
-    );
-    if (source == null) return;
-
-    c.dispatch_set_context(.{ ._ds = source }, @ptrFromInt(@as(usize, @intCast(server_fd))));
-    c.dispatch_source_set_event_handler_f(source, ipcSourceTick);
-    c.dispatch_resume(.{ ._ds = source });
-    g_ipc_source = source;
-}
-
-fn cancelIpcSource() void {
-    if (g_ipc_source) |source| {
-        c.dispatch_source_cancel(source);
-        g_ipc_source = null;
-    }
-}
-
 // Event bridge (called from ObjC shim)
 
 // Thread-safe: AX observer callbacks run on per-app background threads
@@ -2726,7 +2728,6 @@ pub fn main(init: std.process.Init.Minimal) !void {
         log.err("IPC init failed: {}", .{err});
         return err;
     };
-    defer cancelIpcSource();
     defer g_ipc.deinit(g_allocator);
     ipc.g_dispatch = ipcDispatch;
 
@@ -2742,7 +2743,8 @@ pub fn main(init: std.process.Init.Minimal) !void {
     defer ax_observer.deinit();
     setupHotkeyEventTap();
     initWakerSource();
-    initIpcSource(@intCast(g_ipc.fd));
+    try startIpcTransport();
+    defer stopIpcTransport();
     refreshRolePolling();
     observeDiscoveredApps();
 
@@ -2772,6 +2774,7 @@ fn bw_drain_events() void {
     while (g_ring.pop()) |ev| {
         handleEvent(&ev);
     }
+    drainIpcRequests();
 
     // Flush retile BEFORE cleanup so windows are at their layout positions
     // when cleanup checks on-screen status. Without this, cleanup sees
@@ -2828,35 +2831,109 @@ fn gracefulStopNSApp() void {
     app.msgSend(void, "postEvent:atStart:", .{ event, true });
 }
 
-/// Accept and handle one IPC client connection — called by dispatch_source.
-fn bw_handle_ipc_client(server_fd: c_int) void {
-    // std.posix.accept was removed in Zig 0.16; call libc directly.
-    const client_fd = std.c.accept(server_fd, null, null);
-    if (client_fd < 0) {
-        log.err("accept failed: errno={d}", .{std.c._errno().*});
-        return;
-    }
-    defer _ = std.c.close(client_fd);
-    ipc.disableSigpipe(client_fd);
+fn handleIpcRequest(request: IpcRequest) void {
+    defer _ = std.c.close(request.fd);
     const started_ns = nanoTimestamp();
-
-    var buf: [512]u8 = undefined;
-    const n = posix.read(client_fd, &buf) catch |err| {
-        log.err("IPC read: {}", .{err});
-        return;
-    };
-    if (n == 0) return;
-
-    const cmd = std.mem.trimEnd(u8, buf[0..n], &.{ '\n', '\r', ' ', 0 });
-    if (cmd.len == 0) return;
-    log.debug("[trace] ipc recv fd={} bytes={} cmd={s}", .{ client_fd, n, cmd });
+    const cmd = request.buf[0..request.len];
+    log.debug("[trace] ipc recv fd={} bytes={} cmd={s}", .{ request.fd, request.len, cmd });
 
     if (ipc.g_dispatch) |dispatch| {
-        dispatch(cmd, client_fd);
+        dispatch(cmd, request.fd);
         const elapsed_ms = @divTrunc(nanoTimestamp() - started_ns, std.time.ns_per_ms);
-        log.debug("[trace] ipc handled fd={} cmd={s} elapsed_ms={}", .{ client_fd, cmd, elapsed_ms });
+        log.debug("[trace] ipc handled fd={} cmd={s} elapsed_ms={}", .{ request.fd, cmd, elapsed_ms });
     } else {
         log.warn("ipc dispatch callback missing", .{});
+    }
+}
+
+fn drainIpcRequests() void {
+    while (g_ipc_requests.pop()) |request| {
+        handleIpcRequest(request);
+    }
+}
+
+fn configureIpcClient(fd: c_int) void {
+    ipc.disableSigpipe(fd);
+    const timeout: std.c.timeval = .{ .sec = 0, .usec = 250_000 };
+    posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.SNDTIMEO, std.mem.asBytes(&timeout)) catch |err| {
+        log.warn("IPC send timeout setup failed: {}", .{err});
+    };
+}
+
+fn readIpcRequest(fd: c_int) ?IpcRequest {
+    var request: IpcRequest = .{ .fd = fd, .len = 0, .buf = undefined };
+    var written: usize = 0;
+
+    while (written < request.buf.len) {
+        var poll_fds = [_]posix.pollfd{.{
+            .fd = fd,
+            .events = posix.POLL.IN,
+            .revents = 0,
+        }};
+        const ready = posix.poll(&poll_fds, 1000) catch return null;
+        if (ready == 0) return null;
+
+        const n = posix.read(fd, request.buf[written..]) catch return null;
+        if (n == 0) break;
+        written += n;
+    }
+
+    if (written == request.buf.len) {
+        ipc.writeResponse(fd, "err: command too long\n");
+        return null;
+    }
+
+    const command = std.mem.trimEnd(u8, request.buf[0..written], &.{ '\n', '\r', ' ', 0 });
+    if (command.len == 0) return null;
+    request.len = @intCast(command.len);
+    return request;
+}
+
+fn ipcAcceptLoop() void {
+    while (!g_ipc_transport_stop.load(.acquire)) {
+        var poll_fds = [_]posix.pollfd{.{
+            .fd = g_ipc.fd,
+            .events = posix.POLL.IN,
+            .revents = 0,
+        }};
+        const ready = posix.poll(&poll_fds, 250) catch |err| {
+            if (!g_ipc_transport_stop.load(.acquire)) {
+                log.warn("IPC listener poll failed: {}", .{err});
+            }
+            continue;
+        };
+        if (ready == 0) continue;
+
+        const client_fd = std.c.accept(g_ipc.fd, null, null);
+        if (client_fd < 0) continue;
+        configureIpcClient(client_fd);
+
+        const request = readIpcRequest(client_fd) orelse {
+            _ = std.c.close(client_fd);
+            continue;
+        };
+        if (!g_ipc_requests.push(request)) {
+            ipc.writeResponse(client_fd, "err: IPC queue busy\n");
+            _ = std.c.close(client_fd);
+            continue;
+        }
+        signalWaker();
+    }
+}
+
+fn startIpcTransport() !void {
+    std.debug.assert(g_ipc_thread == null);
+    g_ipc_transport_stop.store(false, .release);
+    g_ipc_thread = try std.Thread.spawn(.{}, ipcAcceptLoop, .{});
+}
+
+fn stopIpcTransport() void {
+    g_ipc_transport_stop.store(true, .release);
+    if (g_ipc_thread) |thread| thread.join();
+    g_ipc_thread = null;
+
+    while (g_ipc_requests.pop()) |request| {
+        _ = std.c.close(request.fd);
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -418,26 +418,55 @@ fn focusedWindowIdForLoggedEvent(comptime event_name: []const u8, pid: i32) ?u32
     return focused_wid;
 }
 
-fn focusedManagedLeaderWindow() ?window_mod.Window {
-    const pid = frontmostApplicationPid() orelse return null;
-    const focused_wid = focusedWindowIdForPid(pid) orelse return null;
-
+fn managedLeaderForFocusedWindow(pid: i32, focused_wid: u32) ?window_mod.Window {
+    std.debug.assert(pid > 0);
+    std.debug.assert(focused_wid != 0);
     const leader_wid = g_tab_groups.resolveLeader(focused_wid);
     const leader = g_store.get(leader_wid) orelse return null;
     if (leader.pid != pid) return null;
     return leader;
 }
 
+fn focusedManagedLeaderWindow() ?window_mod.Window {
+    const pid = frontmostApplicationPid() orelse return null;
+    const focused_wid = focusedWindowIdForPid(pid) orelse return null;
+    return managedLeaderForFocusedWindow(pid, focused_wid);
+}
+
 /// Window a hotkey that acts on "the focused window" should target. Asks AX
-/// first: the per-workspace cache only advances on focus notifications that
-/// survive the transition filters, so with two windows of one app it lags a
-/// click and the hotkey lands on the wrong window. Falls back to the cache
-/// when the frontmost app's focused window is unmanaged or sits on a workspace
-/// that is not currently visible, where retile would never place it.
+/// first and synchronizes native-tab state before returning the group's leader:
+/// the per-workspace cache and active-tab record can both lag a user click.
+/// Falls back to the cache during transitions or when reconciliation cannot
+/// produce a visible managed window.
 fn hotkeyTargetWindowId() ?u32 {
-    if (focusedManagedLeaderWindow()) |win| {
-        if (workspaceVisibleOnDisplay(win.workspace_id, win.display_id)) return win.wid;
+    const pid = frontmostApplicationPid() orelse return g_workspaces.active().focused_wid;
+    const focused_wid = focusedWindowIdForPid(pid) orelse return g_workspaces.active().focused_wid;
+
+    if (managedLeaderForFocusedWindow(pid, focused_wid)) |win| {
+        if (workspaceVisibleOnDisplay(win.workspace_id, win.display_id)) {
+            // A known suppressed member can become AX-focused without a
+            // notification reaching the main loop first. The leader owns the
+            // fullscreen flag, but retile must address this active member.
+            if (!g_workspace_transition.isActive()) {
+                _ = syncFocusStateForWindowId(focused_wid, .keyboard);
+            }
+            return win.wid;
+        }
     }
+
+    // Native tabs can replace the focused CG window ID without emitting a
+    // creation event. Do not send the first hotkey after a tab switch to the
+    // stale workspace cache: reconcile the AX-reported ID synchronously, then
+    // resolve it back to the group's slot. Transition focus remains isolated
+    // until its settle window closes, as with asynchronous AX focus events.
+    if (!g_workspace_transition.isActive()) {
+        log.debug("hotkey target reconciling unknown focused window pid={d} wid={d}", .{ pid, focused_wid });
+        reconcileFocusedWindow(pid, focused_wid);
+        if (managedLeaderForFocusedWindow(pid, focused_wid)) |win| {
+            if (workspaceVisibleOnDisplay(win.workspace_id, win.display_id)) return win.wid;
+        }
+    }
+
     return g_workspaces.active().focused_wid;
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,6 +15,7 @@ const tiling = @import("tiling.zig");
 const bsp_mod = tiling.bsp_mod;
 const ipc = @import("ipc.zig");
 const ipc_transport = @import("ipc_transport.zig");
+const signal_transport = @import("signal_transport.zig");
 const tabgroup = @import("tabgroup.zig");
 const config_mod = @import("config.zig");
 const dim = @import("dim.zig");
@@ -1508,9 +1509,6 @@ var g_cleanup_pending_pid_count: usize = 0;
 var g_animator: animation_mod.Animator = undefined;
 var g_animator_source: c.dispatch_source_t = null;
 var g_ipc_transport: ipc_transport.Transport = .{};
-var g_signal_source: c.dispatch_source_t = null;
-var g_signal_read_fd: c_int = -1;
-var g_signal_write_fd: c_int = -1;
 
 const ConfigRuntime = struct {
     arena: std.heap.ArenaAllocator,
@@ -2676,10 +2674,8 @@ pub fn main(init: std.process.Init.Minimal) !void {
     }
 
     // -- Signal transport (handler writes only; cleanup runs on main) --
-    try initSignalTransport();
-    defer deinitSignalTransport();
-    installSignalHandlers();
-    defer uninstallSignalHandlers();
+    try signal_transport.init(gracefulStopNSApp);
+    defer signal_transport.deinit();
     errdefer restoreAllWindows();
 
     // -- Discover existing windows and tile --
@@ -5660,101 +5656,6 @@ fn restoreAllWindows() void {
                 _ = ax_mod.setWindowFrame(win.pid, wid, x, y, w, h);
             }
         }
-    }
-}
-
-/// Graceful signal handler for INT/TERM/HUP/QUIT. `write(2)` is
-/// async-signal-safe; the dispatch read source performs all AppKit and cleanup
-/// work later on the main queue. The pipe is nonblocking, so repeated signals
-/// cannot deadlock a full process in the handler.
-fn gracefulSignalHandler(sig: posix.SIG) callconv(.c) void {
-    const byte: u8 = @intCast(@intFromEnum(sig));
-    _ = c.write(g_signal_write_fd, &byte, 1);
-}
-
-fn signalSourceReady(context: ?*anyopaque) callconv(.c) void {
-    _ = context;
-    if (g_signal_read_fd < 0) return;
-
-    var buf: [64]u8 = undefined;
-    while (c.read(g_signal_read_fd, &buf, buf.len) > 0) {}
-    gracefulStopNSApp();
-}
-
-fn configureSignalPipeFd(fd: c_int) !void {
-    if (c.fcntl(fd, c.F_SETFL, c.O_NONBLOCK) < 0) return error.SignalPipeConfigureFailed;
-    if (c.fcntl(fd, c.F_SETFD, c.FD_CLOEXEC) < 0) return error.SignalPipeConfigureFailed;
-}
-
-fn initSignalTransport() !void {
-    std.debug.assert(g_signal_source == null);
-    std.debug.assert(g_signal_read_fd < 0 and g_signal_write_fd < 0);
-
-    var fds: [2]c_int = undefined;
-    if (c.pipe(&fds) != 0) return error.SignalPipeCreateFailed;
-    errdefer {
-        _ = std.c.close(fds[0]);
-        _ = std.c.close(fds[1]);
-    }
-    try configureSignalPipeFd(fds[0]);
-    try configureSignalPipeFd(fds[1]);
-
-    const source = c.dispatch_source_create(
-        cg_extra.DISPATCH_SOURCE_TYPE_READ(),
-        @intCast(fds[0]),
-        0,
-        cg_extra.dispatch_get_main_queue(),
-    ) orelse return error.SignalSourceCreateFailed;
-
-    g_signal_read_fd = fds[0];
-    g_signal_write_fd = fds[1];
-    g_signal_source = source;
-    c.dispatch_source_set_event_handler_f(source, signalSourceReady);
-    c.dispatch_resume(.{ ._ds = source });
-}
-
-fn deinitSignalTransport() void {
-    if (g_signal_source) |source| {
-        c.dispatch_source_cancel(source);
-        c.dispatch_release(.{ ._ds = source });
-        g_signal_source = null;
-    }
-    if (g_signal_read_fd >= 0) {
-        const fd = g_signal_read_fd;
-        g_signal_read_fd = -1;
-        _ = std.c.close(fd);
-    }
-    if (g_signal_write_fd >= 0) {
-        const fd = g_signal_write_fd;
-        g_signal_write_fd = -1;
-        _ = std.c.close(fd);
-    }
-}
-
-const graceful_signals = [_]posix.SIG{
-    posix.SIG.INT, posix.SIG.TERM,
-    posix.SIG.HUP, posix.SIG.QUIT,
-};
-
-fn installSignalHandlers() void {
-    for (graceful_signals) |sig| {
-        var sa: posix.Sigaction = .{
-            .handler = .{ .handler = gracefulSignalHandler },
-            .mask = posix.sigemptyset(),
-            .flags = posix.SA.RESTART,
-        };
-        posix.sigaction(sig, &sa, null);
-    }
-}
-
-fn uninstallSignalHandlers() void {
-    for (graceful_signals) |sig| {
-        var sa: posix.Sigaction = .{
-            .handler = .{ .handler = posix.SIG.DFL },
-            .mask = posix.sigemptyset(),
-            .flags = 0,
-        };
-        posix.sigaction(sig, &sa, null);
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -3540,10 +3540,10 @@ fn handleEvent(ev: *const event_mod.Event) void {
         },
         .hk_move_workspace_to_display => {
             const arg: u8 = @intCast(ev.wid);
-            if (arg == 0) {
+            if (arg == config_mod.next_display_arg) {
                 log.info("hotkey: move workspace to display next", .{});
                 moveWorkspaceToDisplayNext();
-            } else if (arg == 255) {
+            } else if (arg == config_mod.previous_display_arg) {
                 log.info("hotkey: move workspace to display prev", .{});
                 moveWorkspaceToDisplayPrev();
             } else {

--- a/src/main.zig
+++ b/src/main.zig
@@ -2403,6 +2403,7 @@ fn setRolePolling(enabled: bool) void {
     if (!enabled) {
         if (g_role_poll_source) |source| {
             c.dispatch_source_cancel(source);
+            c.dispatch_release(.{ ._ds = source });
             g_role_poll_source = null;
         }
         return;

--- a/src/main.zig
+++ b/src/main.zig
@@ -14,6 +14,7 @@ const workspace_mod = @import("workspace.zig");
 const tiling = @import("tiling.zig");
 const bsp_mod = tiling.bsp_mod;
 const ipc = @import("ipc.zig");
+const ipc_transport = @import("ipc_transport.zig");
 const tabgroup = @import("tabgroup.zig");
 const config_mod = @import("config.zig");
 const dim = @import("dim.zig");
@@ -56,16 +57,6 @@ pub const std_options = std.Options{
 const log = std.log.scoped(.bobrwm);
 
 const EventQueue = spsc_queue.Queue(event_mod.Event, 1024);
-
-const IpcRequest = struct {
-    fd: c_int,
-    len: u16,
-    buf: [512]u8,
-};
-
-/// One IPC acceptor thread produces complete requests; the main thread drains
-/// them. Socket reads never run on AppKit's queue.
-const IpcRequestQueue = spsc_queue.Queue(IpcRequest, 16);
 
 // Hidden-window position (bottom-right corner, barely visible)
 
@@ -1516,9 +1507,7 @@ var g_cleanup_pending_pid_count: usize = 0;
 
 var g_animator: animation_mod.Animator = undefined;
 var g_animator_source: c.dispatch_source_t = null;
-var g_ipc_requests: IpcRequestQueue = .{};
-var g_ipc_thread: ?std.Thread = null;
-var g_ipc_transport_stop: std.atomic.Value(bool) = .init(false);
+var g_ipc_transport: ipc_transport.Transport = .{};
 var g_signal_source: c.dispatch_source_t = null;
 var g_signal_read_fd: c_int = -1;
 var g_signal_write_fd: c_int = -1;
@@ -2724,8 +2713,8 @@ pub fn main(init: std.process.Init.Minimal) !void {
     defer ax_observer.deinit();
     setupHotkeyEventTap();
     initWakerSource();
-    try startIpcTransport();
-    defer stopIpcTransport();
+    try g_ipc_transport.start(g_ipc.fd, signalWaker);
+    defer g_ipc_transport.stop();
     refreshRolePolling();
     observeDiscoveredApps();
 
@@ -2854,10 +2843,10 @@ fn gracefulStopNSApp() void {
     app.msgSend(void, "postEvent:atStart:", .{ event, true });
 }
 
-fn handleIpcRequest(request: IpcRequest) void {
+fn handleIpcRequest(request: ipc_transport.Request) void {
     defer _ = std.c.close(request.fd);
     const started_ns = nanoTimestamp();
-    const cmd = request.buf[0..request.len];
+    const cmd = request.command();
     log.debug("[trace] ipc recv fd={} bytes={} cmd={s}", .{ request.fd, request.len, cmd });
 
     if (ipc.g_dispatch) |dispatch| {
@@ -2870,93 +2859,8 @@ fn handleIpcRequest(request: IpcRequest) void {
 }
 
 fn drainIpcRequests() void {
-    while (g_ipc_requests.pop()) |request| {
+    while (g_ipc_transport.pop()) |request| {
         handleIpcRequest(request);
-    }
-}
-
-fn configureIpcClient(fd: c_int) void {
-    ipc.disableSigpipe(fd);
-    const timeout: std.c.timeval = .{ .sec = 0, .usec = 250_000 };
-    posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.SNDTIMEO, std.mem.asBytes(&timeout)) catch |err| {
-        log.warn("IPC send timeout setup failed: {}", .{err});
-    };
-}
-
-fn readIpcRequest(fd: c_int) ?IpcRequest {
-    var request: IpcRequest = .{ .fd = fd, .len = 0, .buf = undefined };
-    var written: usize = 0;
-
-    while (written < request.buf.len) {
-        var poll_fds = [_]posix.pollfd{.{
-            .fd = fd,
-            .events = posix.POLL.IN,
-            .revents = 0,
-        }};
-        const ready = posix.poll(&poll_fds, 1000) catch return null;
-        if (ready == 0) return null;
-
-        const n = posix.read(fd, request.buf[written..]) catch return null;
-        if (n == 0) break;
-        written += n;
-    }
-
-    if (written == request.buf.len) {
-        ipc.writeResponse(fd, "err: command too long\n");
-        return null;
-    }
-
-    const command = std.mem.trimEnd(u8, request.buf[0..written], &.{ '\n', '\r', ' ', 0 });
-    if (command.len == 0) return null;
-    request.len = @intCast(command.len);
-    return request;
-}
-
-fn ipcAcceptLoop() void {
-    while (!g_ipc_transport_stop.load(.acquire)) {
-        var poll_fds = [_]posix.pollfd{.{
-            .fd = g_ipc.fd,
-            .events = posix.POLL.IN,
-            .revents = 0,
-        }};
-        const ready = posix.poll(&poll_fds, 250) catch |err| {
-            if (!g_ipc_transport_stop.load(.acquire)) {
-                log.warn("IPC listener poll failed: {}", .{err});
-            }
-            continue;
-        };
-        if (ready == 0) continue;
-
-        const client_fd = std.c.accept(g_ipc.fd, null, null);
-        if (client_fd < 0) continue;
-        configureIpcClient(client_fd);
-
-        const request = readIpcRequest(client_fd) orelse {
-            _ = std.c.close(client_fd);
-            continue;
-        };
-        if (!g_ipc_requests.push(request)) {
-            ipc.writeResponse(client_fd, "err: IPC queue busy\n");
-            _ = std.c.close(client_fd);
-            continue;
-        }
-        signalWaker();
-    }
-}
-
-fn startIpcTransport() !void {
-    std.debug.assert(g_ipc_thread == null);
-    g_ipc_transport_stop.store(false, .release);
-    g_ipc_thread = try std.Thread.spawn(.{}, ipcAcceptLoop, .{});
-}
-
-fn stopIpcTransport() void {
-    g_ipc_transport_stop.store(true, .release);
-    if (g_ipc_thread) |thread| thread.join();
-    g_ipc_thread = null;
-
-    while (g_ipc_requests.pop()) |request| {
-        _ = std.c.close(request.fd);
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -5215,6 +5215,13 @@ fn adoptWindowAsBackgroundTab(win: window_mod.Window) tabgroup.detect.OffscreenO
 /// Updates `display_id` when a user-dragged window crosses monitors.
 /// Returns true when display ownership changed and callers should retile.
 fn updateWindowDisplayAssignment(wid: u32) bool {
+    // AX move/resize notifications also echo every frame bobrwm writes. The
+    // corresponding SkyLight bounds can still describe the previous frame,
+    // so accepting them here corrupts the stored layout target and makes the
+    // next placement look like a no-op. Only a live pointer drag transfers
+    // geometry ownership from the layout back to the user.
+    if (!g_mouse_left_down) return false;
+
     var win = g_store.get(wid) orelse return false;
     const sky = g_sky orelse return false;
 
@@ -5234,13 +5241,8 @@ fn updateWindowDisplayAssignment(wid: u32) bool {
         return false;
     }
 
-    // Only reassign display when the user is actively dragging and the
-    // workspace is visible. Stops our retile from triggering this.
-    if (!g_mouse_left_down) {
-        win.frame = frame;
-        g_store.put(win) catch {};
-        return false;
-    }
+    // Only reassign display while its workspace is visible. A notification
+    // from a hidden window must not transfer ownership to the visible display.
     if (!workspaceVisibleOnDisplay(win.workspace_id, win.display_id)) {
         win.frame = frame;
         g_store.put(win) catch {};

--- a/src/main.zig
+++ b/src/main.zig
@@ -25,6 +25,7 @@ const loginitem = @import("loginitem.zig");
 const objc_classes = @import("objc_classes.zig");
 const animation_mod = @import("animation.zig");
 const ax_mod = @import("ax.zig");
+const spsc_queue = @import("spsc_queue.zig");
 
 extern fn _AXUIElementGetWindow(element: c.AXUIElementRef, wid: *u32) c.AXError;
 
@@ -54,46 +55,7 @@ pub const std_options = std.Options{
 
 const log = std.log.scoped(.bobrwm);
 
-// Fixed-capacity event ring. Producers are serialized by g_ring_lock because
-// AX callbacks run on the observer thread while AppKit and hotkey callbacks run
-// on the main thread. The main-runloop consumer remains lock-free.
-
-const EventRing = struct {
-    const capacity = 1024;
-
-    buf: [capacity]event_mod.Event = undefined,
-    head: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
-    tail: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
-    overflowed: std.atomic.Value(bool) = .init(false),
-    dropped: usize = 0,
-
-    fn push(self: *EventRing, ev: event_mod.Event) void {
-        const t = self.tail.load(.acquire);
-        const next = (t + 1) % capacity;
-        if (next == self.head.load(.acquire)) {
-            self.dropped += 1;
-            self.overflowed.store(true, .release);
-            log.err("event ring full, dropped event kind={s} pid={d} wid={d} total_dropped={d}", .{
-                @tagName(ev.kind), ev.pid, ev.wid, self.dropped,
-            });
-            return;
-        }
-        self.buf[t] = ev;
-        self.tail.store(next, .release);
-    }
-
-    fn pop(self: *EventRing) ?event_mod.Event {
-        const h = self.head.load(.acquire);
-        if (h == self.tail.load(.acquire)) return null; // empty
-        const ev = self.buf[h];
-        self.head.store((h + 1) % capacity, .release);
-        return ev;
-    }
-
-    fn takeOverflowed(self: *EventRing) bool {
-        return self.overflowed.swap(false, .acq_rel);
-    }
-};
+const EventQueue = spsc_queue.Queue(event_mod.Event, 1024);
 
 const IpcRequest = struct {
     fd: c_int,
@@ -103,30 +65,7 @@ const IpcRequest = struct {
 
 /// One IPC acceptor thread produces complete requests; the main thread drains
 /// them. Socket reads never run on AppKit's queue.
-const IpcRequestRing = struct {
-    const capacity = 16;
-
-    buf: [capacity]IpcRequest = undefined,
-    head: std.atomic.Value(usize) = .init(0),
-    tail: std.atomic.Value(usize) = .init(0),
-
-    fn push(self: *IpcRequestRing, request: IpcRequest) bool {
-        const tail = self.tail.load(.monotonic);
-        const next = (tail + 1) % capacity;
-        if (next == self.head.load(.acquire)) return false;
-        self.buf[tail] = request;
-        self.tail.store(next, .release);
-        return true;
-    }
-
-    fn pop(self: *IpcRequestRing) ?IpcRequest {
-        const head = self.head.load(.monotonic);
-        if (head == self.tail.load(.acquire)) return null;
-        const request = self.buf[head];
-        self.head.store((head + 1) % capacity, .release);
-        return request;
-    }
-};
+const IpcRequestQueue = spsc_queue.Queue(IpcRequest, 16);
 
 // Hidden-window position (bottom-right corner, barely visible)
 
@@ -1516,8 +1455,10 @@ fn framesEqual(lhs: window_mod.Window.Frame, rhs: window_mod.Window.Frame) bool 
 
 // Globals
 
-var g_ring: EventRing = .{};
-/// Protects g_ring.push from concurrent AX observer threads.
+var g_event_queue: EventQueue = .{};
+var g_event_overflowed: std.atomic.Value(bool) = .init(false);
+var g_event_dropped: usize = 0;
+/// Serializes producers before they enter the single-producer event queue.
 var g_ring_lock: c.os_unfair_lock_s = .{ ._os_unfair_lock_opaque = 0 };
 var g_sky: ?skylight.SkyLight = null;
 var g_allocator: std.mem.Allocator = undefined;
@@ -1575,7 +1516,7 @@ var g_cleanup_pending_pid_count: usize = 0;
 
 var g_animator: animation_mod.Animator = undefined;
 var g_animator_source: c.dispatch_source_t = null;
-var g_ipc_requests: IpcRequestRing = .{};
+var g_ipc_requests: IpcRequestQueue = .{};
 var g_ipc_thread: ?std.Thread = null;
 var g_ipc_transport_stop: std.atomic.Value(bool) = .init(false);
 var g_signal_source: c.dispatch_source_t = null;
@@ -2524,12 +2465,20 @@ fn setupHotkeyEventTap() void {
 // and push events here.  The os_unfair_lock serialises concurrent pushes
 // while the main-thread consumer (pop) is wait-free.
 export fn bw_emit_event(kind: u8, pid: i32, wid: u32) void {
-    c.os_unfair_lock_lock(&g_ring_lock);
-    g_ring.push(.{
+    const event: event_mod.Event = .{
         .kind = @enumFromInt(kind),
         .pid = pid,
         .wid = wid,
-    });
+    };
+
+    c.os_unfair_lock_lock(&g_ring_lock);
+    if (!g_event_queue.push(event)) {
+        g_event_dropped += 1;
+        g_event_overflowed.store(true, .release);
+        log.err("event queue full, dropped event kind={s} pid={d} wid={d} total_dropped={d}", .{
+            @tagName(event.kind), event.pid, event.wid, g_event_dropped,
+        });
+    }
     c.os_unfair_lock_unlock(&g_ring_lock);
     signalWaker();
 }
@@ -2814,12 +2763,12 @@ fn bw_drain_events() void {
 
     refreshTabGroupActiveTabs();
 
-    while (g_ring.pop()) |ev| {
+    while (g_event_queue.pop()) |ev| {
         handleEvent(&ev);
     }
     drainIpcRequests();
 
-    if (g_ring.takeOverflowed()) {
+    if (g_event_overflowed.swap(false, .acq_rel)) {
         g_event_overflow_recovery_pending = true;
         refreshRolePolling();
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -2630,6 +2630,7 @@ fn parseConfigPath(process_args: std.process.Args) ?[]const u8 {
 pub fn main(init: std.process.Init.Minimal) !void {
     // Before any thread starts, so logFn never races on the descriptor.
     filelog.init();
+    defer filelog.deinit();
     log.info("bobrwm starting (log_level={s})...", .{@tagName(std_options.log_level)});
 
     var debug_allocator: ?std.heap.DebugAllocator(.{}) = switch (builtin.mode) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1585,6 +1585,9 @@ var g_animator_source: c.dispatch_source_t = null;
 var g_ipc_requests: IpcRequestRing = .{};
 var g_ipc_thread: ?std.Thread = null;
 var g_ipc_transport_stop: std.atomic.Value(bool) = .init(false);
+var g_signal_source: c.dispatch_source_t = null;
+var g_signal_read_fd: c_int = -1;
+var g_signal_write_fd: c_int = -1;
 
 const ConfigRuntime = struct {
     arena: std.heap.ArenaAllocator,
@@ -2741,8 +2744,11 @@ pub fn main(init: std.process.Init.Minimal) !void {
         g_workspaces.workspaces[i].name = name;
     }
 
-    // -- Crash handlers (restore hidden windows on abnormal exit) --
-    installCrashHandlers();
+    // -- Signal transport (handler writes only; cleanup runs on main) --
+    try initSignalTransport();
+    defer deinitSignalTransport();
+    installSignalHandlers();
+    defer uninstallSignalHandlers();
     errdefer restoreAllWindows();
 
     // -- Discover existing windows and tile --
@@ -2825,14 +2831,6 @@ fn bw_drain_events() void {
     // here and never enters the snapshot path — no call, no loop, no reliance
     // on the optimizer eliding a no-op body.
     if (dim.enabled) pushDimSnapshot();
-
-    // Honour pending Ctrl-C / SIGTERM by exiting NSApp.run cleanly so the
-    // deferred cleanup (IPC socket unlink, layout free, restoreAllWindows)
-    // actually runs. Without this, NSApp keeps spinning and the next launch
-    // sees a live socket and bails out with AddressInUse.
-    if (g_shutdown_requested.load(.acquire)) {
-        gracefulStopNSApp();
-    }
 }
 
 /// A dropped event has unknown semantics, so recover from authoritative OS
@@ -5765,7 +5763,7 @@ fn observeDiscoveredApps() void {
     }
 }
 
-// Crash / exit recovery — restore all hidden windows to screen center
+// Exit recovery — restore all hidden windows to screen center
 
 fn restoreAllWindows() void {
     // Undo any inactive-window dimming so windows are left undimmed.
@@ -5788,67 +5786,96 @@ fn restoreAllWindows() void {
     }
 }
 
-var g_shutdown_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
-
-/// Graceful signal handler for INT/TERM/HUP/QUIT. Sets a flag and wakes the
-/// run loop so restoreAllWindows() runs on the main thread where AX calls and
-/// hash table access are safe. Only uses async-signal-safe operations.
-///
-/// CFRunLoopStop alone does NOT exit `[NSApp run]` reliably: NSApplication
-/// re-enters the CFRunLoop internally, so a stop is a no-op for its outer
-/// loop. Instead we set a flag and wake the existing waker source; the main
-/// thread (in bw_drain_events) sees the flag and performs `[NSApp stop:]` +
-/// posts a dummy event, which is the documented way to exit NSApp.run.
-///
-/// Zig 0.16 made `posix.SIG` an enum; the kernel-facing handler signature now
-/// takes that enum directly rather than `c_int`.
+/// Graceful signal handler for INT/TERM/HUP/QUIT. `write(2)` is
+/// async-signal-safe; the dispatch read source performs all AppKit and cleanup
+/// work later on the main queue. The pipe is nonblocking, so repeated signals
+/// cannot deadlock a full process in the handler.
 fn gracefulSignalHandler(sig: posix.SIG) callconv(.c) void {
-    _ = sig;
-    g_shutdown_requested.store(true, .release);
-    signalWaker();
+    const byte: u8 = @intCast(@intFromEnum(sig));
+    _ = c.write(g_signal_write_fd, &byte, 1);
 }
 
-/// Crash signal handler for SEGV/BUS/TRAP/ABRT. Best-effort restore using
-/// async-signal-unsafe functions. May deadlock if the crash occurs mid-
-/// allocation or mid-hash-table-mutation, but leaving windows hidden is worse.
-fn crashSignalHandler(sig: posix.SIG) callconv(.c) void {
-    restoreAllWindows();
+fn signalSourceReady(context: ?*anyopaque) callconv(.c) void {
+    _ = context;
+    if (g_signal_read_fd < 0) return;
 
-    // Re-raise with default handler so the OS produces a core dump / correct exit code.
-    var default_sa: posix.Sigaction = .{
-        .handler = .{ .handler = posix.SIG.DFL },
-        .mask = posix.sigemptyset(),
-        .flags = 0,
-    };
-    posix.sigaction(sig, &default_sa, null);
-    posix.raise(sig) catch {};
+    var buf: [64]u8 = undefined;
+    while (c.read(g_signal_read_fd, &buf, buf.len) > 0) {}
+    gracefulStopNSApp();
 }
 
-fn installCrashHandlers() void {
-    // Graceful signals: handled safely via run loop stop + main-thread cleanup
-    const graceful_signals = [_]posix.SIG{
-        posix.SIG.INT, posix.SIG.TERM,
-        posix.SIG.HUP, posix.SIG.QUIT,
-    };
+fn configureSignalPipeFd(fd: c_int) !void {
+    if (c.fcntl(fd, c.F_SETFL, c.O_NONBLOCK) < 0) return error.SignalPipeConfigureFailed;
+    if (c.fcntl(fd, c.F_SETFD, c.FD_CLOEXEC) < 0) return error.SignalPipeConfigureFailed;
+}
+
+fn initSignalTransport() !void {
+    std.debug.assert(g_signal_source == null);
+    std.debug.assert(g_signal_read_fd < 0 and g_signal_write_fd < 0);
+
+    var fds: [2]c_int = undefined;
+    if (c.pipe(&fds) != 0) return error.SignalPipeCreateFailed;
+    errdefer {
+        _ = std.c.close(fds[0]);
+        _ = std.c.close(fds[1]);
+    }
+    try configureSignalPipeFd(fds[0]);
+    try configureSignalPipeFd(fds[1]);
+
+    const source = c.dispatch_source_create(
+        cg_extra.DISPATCH_SOURCE_TYPE_READ(),
+        @intCast(fds[0]),
+        0,
+        cg_extra.dispatch_get_main_queue(),
+    ) orelse return error.SignalSourceCreateFailed;
+
+    g_signal_read_fd = fds[0];
+    g_signal_write_fd = fds[1];
+    g_signal_source = source;
+    c.dispatch_source_set_event_handler_f(source, signalSourceReady);
+    c.dispatch_resume(.{ ._ds = source });
+}
+
+fn deinitSignalTransport() void {
+    if (g_signal_source) |source| {
+        c.dispatch_source_cancel(source);
+        c.dispatch_release(.{ ._ds = source });
+        g_signal_source = null;
+    }
+    if (g_signal_read_fd >= 0) {
+        const fd = g_signal_read_fd;
+        g_signal_read_fd = -1;
+        _ = std.c.close(fd);
+    }
+    if (g_signal_write_fd >= 0) {
+        const fd = g_signal_write_fd;
+        g_signal_write_fd = -1;
+        _ = std.c.close(fd);
+    }
+}
+
+const graceful_signals = [_]posix.SIG{
+    posix.SIG.INT, posix.SIG.TERM,
+    posix.SIG.HUP, posix.SIG.QUIT,
+};
+
+fn installSignalHandlers() void {
     for (graceful_signals) |sig| {
         var sa: posix.Sigaction = .{
             .handler = .{ .handler = gracefulSignalHandler },
             .mask = posix.sigemptyset(),
-            .flags = 0,
+            .flags = posix.SA.RESTART,
         };
         posix.sigaction(sig, &sa, null);
     }
+}
 
-    // Crash signals: best-effort restore, then re-raise for core dump
-    const crash_signals = [_]posix.SIG{
-        posix.SIG.ABRT, posix.SIG.SEGV,
-        posix.SIG.BUS,  posix.SIG.TRAP,
-    };
-    for (crash_signals) |sig| {
+fn uninstallSignalHandlers() void {
+    for (graceful_signals) |sig| {
         var sa: posix.Sigaction = .{
-            .handler = .{ .handler = crashSignalHandler },
+            .handler = .{ .handler = posix.SIG.DFL },
             .mask = posix.sigemptyset(),
-            .flags = posix.SA.RESETHAND, // one-shot: avoid infinite re-entry
+            .flags = 0,
         };
         posix.sigaction(sig, &sa, null);
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -202,13 +202,6 @@ const WorkspaceTraversalDirection = enum {
     next,
 };
 
-pub const StatusBarAction = union(enum) {
-    open_config,
-    previous_workspace,
-    next_workspace,
-    workspace: workspace_mod.WorkspaceId,
-};
-
 const HotkeyEvent = struct {
     kind: u8,
     arg: u32,
@@ -2541,32 +2534,31 @@ export fn bw_emit_event(kind: u8, pid: i32, wid: u32) void {
     signalWaker();
 }
 
-/// Callback target for BWObserver.appTerminated:. Called from
-/// objc_classes.zig so it no longer needs C-symbol export.
-pub fn bw_workspace_app_terminated(pid: i32) void {
+/// Callback target for BWObserver.appTerminated:.
+fn workspaceAppTerminated(pid: i32) void {
     std.debug.assert(pid > 0);
     bw_emit_event(shim.BW_EVENT_APP_TERMINATED, pid, 0);
 }
 
 /// Callback target for BWObserver.appLaunched:.
-pub fn bw_workspace_app_launched(pid: i32) void {
+fn workspaceAppLaunched(pid: i32) void {
     std.debug.assert(pid > 0);
     bw_emit_event(shim.BW_EVENT_APP_LAUNCHED, pid, 0);
 }
 
 /// Callback target for BWObserver.activeAppChanged:.
-pub fn bw_workspace_active_app_changed(pid: i32) void {
+fn workspaceActiveAppChanged(pid: i32) void {
     std.debug.assert(pid > 0);
     bw_emit_event(shim.BW_EVENT_WINDOW_FOCUSED, pid, 0);
 }
 
 /// Callback target for BWObserver.spaceChanged:.
-pub fn bw_workspace_space_changed() void {
+fn workspaceSpaceChanged() void {
     bw_emit_event(shim.BW_EVENT_SPACE_CHANGED, 0, 0);
 }
 
 /// Callback target for BWObserver.displayChanged:.
-pub fn bw_workspace_display_changed() void {
+fn workspaceDisplayChanged() void {
     bw_emit_event(shim.BW_EVENT_DISPLAY_CHANGED, 0, 0);
 }
 
@@ -2768,7 +2760,13 @@ pub fn main(init: std.process.Init.Minimal) !void {
     // -- NSApp (zig-objc) --
     // Register runtime ObjC classes (BWObserver / BWLaunchGate) before
     // any code does objc.getClass on them.
-    objc_classes.register(g_allocator);
+    objc_classes.register(g_allocator, .{
+        .app_launched = workspaceAppLaunched,
+        .app_terminated = workspaceAppTerminated,
+        .active_app_changed = workspaceActiveAppChanged,
+        .space_changed = workspaceSpaceChanged,
+        .display_changed = workspaceDisplayChanged,
+    });
     const NSApp = initApp();
     initWorkspaceObservers();
 
@@ -2783,7 +2781,18 @@ pub fn main(init: std.process.Init.Minimal) !void {
     observeDiscoveredApps();
 
     // Status bar (zig-objc) --
-    statusbar.init(g_workspaces.workspaces[0..g_workspaces.workspace_count], &g_config);
+    statusbar.init(
+        g_workspaces.workspaces[0..g_workspaces.workspace_count],
+        &g_config,
+        .{
+            .retile = statusBarRetile,
+            .open_config = statusBarOpenConfig,
+            .previous_workspace = statusBarPreviousWorkspace,
+            .next_workspace = statusBarNextWorkspace,
+            .switch_to_workspace = statusBarSwitchToWorkspace,
+            .quit = statusBarQuit,
+        },
+    );
     defer statusbar.deinit();
     updateStatusBar();
 
@@ -3002,24 +3011,38 @@ fn stopIpcTransport() void {
     }
 }
 
-/// Clean shutdown — called from the menu bar UI's quit action.
-pub fn bw_will_quit() void {
-    restoreAllWindows();
-}
-
-/// Retile — called from the menu bar UI's retile action.
-pub fn bw_retile() void {
+// Menu callbacks run on the main thread while AppKit dismisses the menu, so
+// state mutations are safe here. Keeping them in the application root makes
+// the UI adapter depend only on the callbacks it is given.
+fn statusBarRetile() callconv(.c) void {
     retile();
 }
 
-/// Dispatch a menu bar action on the main thread.
-pub fn bw_status_bar_action(action: StatusBarAction) void {
-    switch (action) {
-        .open_config => openConfigFile(),
-        .previous_workspace => switchAdjacentWorkspace(.previous),
-        .next_workspace => switchAdjacentWorkspace(.next),
-        .workspace => |workspace_id| switchWorkspace(workspace_id),
-    }
+fn statusBarOpenConfig() callconv(.c) void {
+    openConfigFile();
+}
+
+fn statusBarPreviousWorkspace() callconv(.c) void {
+    switchAdjacentWorkspace(.previous);
+}
+
+fn statusBarNextWorkspace() callconv(.c) void {
+    switchAdjacentWorkspace(.next);
+}
+
+fn statusBarSwitchToWorkspace(workspace_id: u8) callconv(.c) void {
+    if (workspace_id == 0 or workspace_id > g_workspaces.workspace_count) return;
+    switchWorkspace(workspace_id);
+}
+
+/// Restore windows before asking AppKit to terminate; the UI library must not
+/// own shutdown because restoration mutates all window-management state.
+fn statusBarQuit() callconv(.c) void {
+    restoreAllWindows();
+
+    const NSApplication = objc.getClass("NSApplication").?;
+    const app = NSApplication.msgSend(objc.Object, "sharedApplication", .{});
+    app.msgSend(void, "terminate:", .{@as(objc.Object, .{ .value = null })});
 }
 
 fn openConfigFile() void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -2386,6 +2386,8 @@ fn rebuildTilingStatesForConfig() void {
 }
 
 fn applyReloadedConfig(next: ConfigRuntime) void {
+    std.debug.assert(config_mod.workspaceCount(&next.config) == g_workspaces.workspace_count);
+
     var replacement = next;
     replacement.config.applyKeybinds(&replacement.keybind_table);
 
@@ -2402,13 +2404,6 @@ fn applyReloadedConfig(next: ConfigRuntime) void {
     for (g_workspaces.workspaces[0..g_workspaces.workspace_count], 0..) |*ws, i| {
         ws.name = if (i < g_config.workspace_names.len) g_config.workspace_names[i] else "";
     }
-    if (g_config.workspace_names.len > 0 and g_config.workspace_names.len != g_workspaces.workspace_count) {
-        log.warn("config reload cannot change workspace count ({d} running, {d} configured); restart to apply the new count", .{
-            g_workspaces.workspace_count,
-            g_config.workspace_names.len,
-        });
-    }
-
     // Preserve BSP topology and runtime split edits for ordinary config saves.
     // Only changing the layout algorithm requires reconstructing state.
     if (layout_changed) rebuildTilingStatesForConfig();
@@ -2442,11 +2437,21 @@ fn notifyConfigReloadFailed() void {
 
 fn reloadConfig() bool {
     const path = g_config_path orelse return false;
-    const next = ConfigRuntime.init(g_allocator, path, false) catch |err| {
+    var next = ConfigRuntime.init(g_allocator, path, false) catch |err| {
         log.err("config reload failed, keeping current config: {}", .{err});
         notifyConfigReloadFailed();
         return false;
     };
+    const configured_count = config_mod.workspaceCount(&next.config);
+    if (configured_count != g_workspaces.workspace_count) {
+        log.err("config reload cannot change workspace count ({d} running, {d} configured); restart to apply it", .{
+            g_workspaces.workspace_count,
+            configured_count,
+        });
+        next.deinit();
+        notifyConfigReloadFailed();
+        return false;
+    }
     applyReloadedConfig(next);
     return true;
 }
@@ -2694,6 +2699,16 @@ pub fn main(init: std.process.Init.Minimal) !void {
     defer deinitAxStrings();
     defer ax_mod.deinitElementCache();
 
+    // Claim the single-instance endpoint before config reconciliation,
+    // accessibility prompts, SkyLight, or window discovery can mutate any
+    // external state. A losing second launch must be completely inert.
+    g_ipc = ipc.Server.init(g_allocator) catch |err| {
+        log.err("IPC init failed: {}", .{err});
+        return err;
+    };
+    defer g_ipc.deinit(g_allocator);
+    ipc.g_dispatch = ipcDispatch;
+
     // -- Config --
     const config_path = config_mod.resolvePath(g_allocator, parseConfigPath(init.args)) catch null;
     defer if (config_path) |path| g_allocator.free(path);
@@ -2723,10 +2738,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
     // -- Core state --
     g_store = window_mod.WindowStore.init(g_allocator);
     defer g_store.deinit();
-    const ws_count: u8 = if (g_config.workspace_names.len > 0)
-        @intCast(g_config.workspace_names.len)
-    else
-        workspace_mod.max_workspaces;
+    const ws_count = config_mod.workspaceCount(&g_config);
     g_workspaces = workspace_mod.WorkspaceManager.init(g_allocator, ws_count);
     defer g_workspaces.deinit();
     clearTilingStates();
@@ -2807,14 +2819,6 @@ pub fn main(init: std.process.Init.Minimal) !void {
     discoverWindows();
     log.info("discovered {} windows", .{g_store.count()});
     retileAllDisplays();
-
-    // -- IPC server --
-    g_ipc = ipc.Server.init(g_allocator) catch |err| {
-        log.err("IPC init failed: {}", .{err});
-        return err;
-    };
-    defer g_ipc.deinit(g_allocator);
-    ipc.g_dispatch = ipcDispatch;
 
     // -- NSApp (zig-objc) --
     // Register runtime ObjC classes (BWObserver / BWLaunchGate) before
@@ -3718,27 +3722,39 @@ fn handleEvent(ev: *const event_mod.Event) void {
                 return;
             }
 
+            // A suppressed tab can become a standalone window during the
+            // drag. Resolve layout ownership only after that reconciliation:
+            // native-tab AX notifications carry the physical member wid,
+            // while workspace and BSP state carry the group leader.
+            const tab_dragged_out = checkTabDragOut(ev.pid, ev.wid);
+            const layout_wid = g_tab_groups.resolveLeader(ev.wid);
+
             if (updateDraggedWindowGeometry(ev.wid, observed)) {
                 retile();
                 return;
             }
+            if (tab_dragged_out) {
+                if (g_store.get(layout_wid)) |win| {
+                    _ = maybeSetFocusedDisplayForWindow(win, .drag);
+                }
+                retile();
+            }
             // Snap fullscreen windows back to display frame
-            if (g_store.get(ev.wid)) |win| {
+            if (g_store.get(layout_wid)) |win| {
                 if (win.is_fullscreen) {
                     retile();
                     return;
                 }
             }
-            checkTabDragOut(ev.pid, ev.wid);
             if (g_pointer_drag_wid == ev.wid) {
-                if (g_store.get(ev.wid)) |win| {
+                if (g_store.get(layout_wid)) |win| {
                     if (win.mode == .tiled and !win.is_fullscreen and workspaceVisibleOnDisplay(win.workspace_id, win.display_id)) {
                         g_drag_reconcile_on_drop = true;
                     }
                 }
             }
             if (ev.kind == .window_moved) {
-                updateWindowMovePreview(ev.wid);
+                updateWindowMovePreview(layout_wid);
             } else {
                 clearDragPreview();
             }
@@ -5444,42 +5460,63 @@ fn adoptWindowAsBackgroundTab(win: window_mod.Window) tabgroup.detect.OffscreenO
     return .adopt;
 }
 
-/// Adopt geometry from the exact window claimed by a real pointer drag.
+/// Adopt geometry from the exact window claimed by a real pointer drag while
+/// mutating workspace/layout ownership through its native-tab group leader.
 /// Returns true when display ownership changed and callers should retile.
-fn updateDraggedWindowGeometry(wid: u32, frame: window_mod.Window.Frame) bool {
-    if (g_pointer_drag_wid != wid) return false;
-    var win = g_store.get(wid) orelse return false;
+fn updateDraggedWindowGeometry(dragged_wid: u32, frame: window_mod.Window.Frame) bool {
+    if (g_pointer_drag_wid != dragged_wid) return false;
+    const leader_wid = g_tab_groups.resolveLeader(dragged_wid);
+    const leader = g_store.get(leader_wid) orelse return false;
     const next_display_id = displayIdForFrame(frame);
-    if (next_display_id == win.display_id) {
-        win.frame = frame;
-        if (win.mode == .floating and !win.is_fullscreen) win.float_frame = frame;
-        g_store.put(win) catch {};
+    if (next_display_id == leader.display_id) {
+        adoptDraggedFrame(dragged_wid, leader_wid, frame);
         return false;
     }
 
     // Only reassign display while its workspace is visible. A notification
     // from a hidden window must not transfer ownership to the visible display.
-    if (!workspaceVisibleOnDisplay(win.workspace_id, win.display_id)) {
-        win.frame = frame;
-        g_store.put(win) catch {};
+    if (!workspaceVisibleOnDisplay(leader.workspace_id, leader.display_id)) {
+        adoptDraggedFrame(dragged_wid, leader_wid, frame);
         return false;
     }
 
-    removeFromTiling(win.workspace_id, wid);
-    win.frame = frame;
-    if (win.mode == .floating and !win.is_fullscreen) win.float_frame = frame;
-    win.display_id = next_display_id;
-    g_store.put(win) catch return false;
-    if (win.mode == .tiled) {
-        insertIntoTiling(win.workspace_id, wid);
-    }
+    if (!reassignManagedWindowToDisplay(leader_wid, next_display_id)) return false;
+    adoptDraggedFrame(dragged_wid, leader_wid, frame);
 
-    if (!workspaceVisibleOnDisplay(win.workspace_id, win.display_id)) {
-        hideWindow(win.pid, wid);
+    if (g_store.get(leader_wid)) |updated| {
+        _ = maybeSetFocusedDisplayForWindow(updated, .drag);
     }
-    _ = maybeSetFocusedDisplayForWindow(win, .drag);
-    log.info("window moved to display wid={d} display={d}", .{ wid, win.display_id });
+    log.info("window moved to display dragged_wid={d} leader={d} display={d}", .{
+        dragged_wid,
+        leader_wid,
+        next_display_id,
+    });
     return true;
+}
+
+/// Keep the physical tab and its layout owner in sync after accepting a real
+/// pointer sample. Other members are placed from the canonical frame by the
+/// next retile; writing them during the drag would fight AppKit's tab motion.
+fn adoptDraggedFrame(
+    dragged_wid: u32,
+    leader_wid: u32,
+    frame: window_mod.Window.Frame,
+) void {
+    if (g_store.get(dragged_wid)) |dragged| {
+        var updated = dragged;
+        updated.frame = frame;
+        if (updated.mode == .floating and !updated.is_fullscreen) updated.float_frame = frame;
+        g_store.putAssumeCapacity(updated);
+    }
+    if (leader_wid != dragged_wid) {
+        if (g_store.get(leader_wid)) |leader| {
+            var updated = leader;
+            updated.frame = frame;
+            if (updated.mode == .floating and !updated.is_fullscreen) updated.float_frame = frame;
+            g_store.putAssumeCapacity(updated);
+        }
+    }
+    g_tab_groups.updateFrame(leader_wid, frame);
 }
 
 /// Apply ownership policy to geometry changed without an active pointer drag.
@@ -6072,13 +6109,13 @@ fn reconcileFocusedWindow(pid: i32, focused_wid: u32) void {
 /// Called on window_moved / window_resized — detects tab drag-out.
 /// When a suppressed tab's bounds diverge from its group's canonical frame,
 /// promote it to a standalone tiled window.
-fn checkTabDragOut(_: i32, wid: u32) void {
-    const g = g_tab_groups.groupOfMut(wid) orelse return;
-    if (g.active_wid == wid) return; // only check suppressed members
+fn checkTabDragOut(_: i32, wid: u32) bool {
+    const g = g_tab_groups.groupOfMut(wid) orelse return false;
+    if (g.active_wid == wid) return false; // only check suppressed members
 
-    const frame = liveWindowFrame(wid) orelse return;
+    const frame = liveWindowFrame(wid) orelse return false;
     switch (tabgroup.detect.classifyMember(frame, g.canonical_frame, isVisibleOnScreen(wid))) {
-        .keep => return,
+        .keep => return false,
         .promote_to_standalone => {},
     }
 
@@ -6089,12 +6126,11 @@ fn checkTabDragOut(_: i32, wid: u32) void {
     if (g_store.get(wid)) |win| {
         var updated = win;
         updated.frame = frame;
-        updated.display_id = displayIdForFrame(frame);
-        g_store.put(updated) catch return;
+        g_store.put(updated) catch return false;
     }
 
-    const win = g_store.get(wid) orelse return;
-    const ws = g_workspaces.get(win.workspace_id) orelse return;
+    const win = g_store.get(wid) orelse return false;
+    const ws = g_workspaces.get(win.workspace_id) orelse return false;
 
     // If the dragged-out tab led the group, its existing workspace/layout
     // slot belongs to the surviving group — hand it to the new leader before
@@ -6114,11 +6150,10 @@ fn checkTabDragOut(_: i32, wid: u32) void {
         }
     }
     if (!wid_in_ws) {
-        ws.addWindow(wid) catch return;
+        ws.addWindow(wid) catch return false;
         insertIntoTiling(win.workspace_id, wid);
     }
     ws.recordFocus(wid);
-    _ = maybeSetFocusedDisplayForWindow(win, .drag);
 
     // If the group dissolved, verify the survivor is still managed
     switch (removal) {
@@ -6139,7 +6174,7 @@ fn checkTabDragOut(_: i32, wid: u32) void {
         .none, .leader_changed => {},
     }
 
-    retile();
+    return true;
 }
 
 // Workspace resolution (config-based app → workspace mapping)
@@ -6178,6 +6213,8 @@ fn frameCenterOnDisplay(frame: window_mod.Window.Frame, display: shim.bw_frame) 
 fn workspaceRevealSettled(ws: *const workspace_mod.Workspace, display_id: u32) bool {
     const display_slot = displayIndexById(display_id) orelse return false;
     const display = g_displays[display_slot].visible;
+    const on_screen = OnScreenWindows.snapshot();
+    if (on_screen.truncated) return false;
 
     for (ws.windows.items) |leader_wid| {
         const visible_wid = g_tab_groups.resolveActive(leader_wid);
@@ -6186,6 +6223,9 @@ fn workspaceRevealSettled(ws: *const workspace_mod.Workspace, display_id: u32) b
         if (win.workspace_id != ws.id or win.display_id != display_id) return false;
         if (!frameCenterOnDisplay(win.frame, display)) return false;
 
+        // CG can retain layer-0 Electron windows (and stale native-tab IDs)
+        // with plausible bounds after they stop contributing pixels.
+        if (!on_screen.contains(visible_wid)) return false;
         const actual = liveWindowFrame(visible_wid) orelse return false;
         if (!workspace_mod.frameCoversTarget(actual, win.frame)) return false;
     }
@@ -6575,9 +6615,10 @@ fn moveWindowToWorkspace(target_id: u8) void {
     retile();
 }
 
-/// Move a managed window to a target display and map it onto the target
-/// display's active workspace so it stays visible after the move.
-fn moveManagedWindowToDisplay(wid: u32, target_display_id: u32) bool {
+/// Update every ownership structure for a cross-display move. The caller owns
+/// focus policy and the final retile so pointer drags can first adopt the
+/// physical tab's latest frame.
+fn reassignManagedWindowToDisplay(wid: u32, target_display_id: u32) bool {
     std.debug.assert(wid != 0);
     std.debug.assert(target_display_id != 0);
 
@@ -6625,7 +6666,16 @@ fn moveManagedWindowToDisplay(wid: u32, target_display_id: u32) bool {
         updateTabGroupAssignment(wid, source_workspace_id, target_display_id);
     }
 
-    _ = maybeSetFocusedDisplayForWindow(win, .keyboard);
+    return true;
+}
+
+/// Move a managed window to a target display and map it onto the target
+/// display's active workspace so it stays visible after the move.
+fn moveManagedWindowToDisplay(wid: u32, target_display_id: u32) bool {
+    if (!reassignManagedWindowToDisplay(wid, target_display_id)) return false;
+    if (g_store.get(wid)) |win| {
+        _ = maybeSetFocusedDisplayForWindow(win, .keyboard);
+    }
     retile();
     return true;
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -27,6 +27,7 @@ const loginitem = @import("loginitem.zig");
 const objc_classes = @import("objc_classes.zig");
 const animation_mod = @import("animation.zig");
 const ax_mod = @import("ax.zig");
+const geometry_mod = @import("geometry.zig");
 const spsc_queue = @import("spsc_queue.zig");
 
 extern fn _AXUIElementGetWindow(element: c.AXUIElementRef, wid: *u32) c.AXError;
@@ -73,6 +74,9 @@ const app_launch_retry_attempts_max: u8 = 10;
 /// Capacity reserved for wid-keyed role/deferred maps to avoid growth churn.
 const pending_role_window_capacity: usize = 256;
 const deferred_window_candidate_capacity: usize = 256;
+/// Geometry entries are wid-keyed and include suppressed native-tab members.
+/// Match the bounded WindowServer snapshots used by discovery and cleanup.
+const geometry_window_capacity: u32 = 512;
 /// Capacity reserved for app launch retries (pid-keyed, bounded by observers).
 const app_launch_retry_capacity: usize = 64;
 /// Focus query retry budget. Electron apps (Discord) can report no AX
@@ -919,6 +923,7 @@ fn reconcileVisibleFramesFromWindowServer() void {
             .width = rect.size.width,
             .height = rect.size.height,
         };
+        seedObservedFrame(win.wid, frame);
         if (framesEqual(win.frame, frame)) continue;
 
         log.debug("frame reconcile wid={d} stored x={d:.0} y={d:.0} w={d:.0} h={d:.0} actual x={d:.0} y={d:.0} w={d:.0} h={d:.0}", .{
@@ -1264,9 +1269,9 @@ fn inferDisplayIdForWindow(wid: u32) ?u32 {
     return displayIdForFrame(frame);
 }
 
-/// Live WindowServer bounds for a window. Floating geometry is not kept in the
-/// store on user drags, so callers that need where a window actually *is* must
-/// ask WindowServer rather than trust `Window.frame`.
+/// Live WindowServer bounds for a window. `Window.frame` records bobrwm's last
+/// accepted target or adopted user/external geometry; callers that need what
+/// is physically visible now must still ask WindowServer.
 fn liveWindowFrame(wid: u32) ?window_mod.Window.Frame {
     const sky = g_sky orelse return null;
     var rect: skylight.CGRect = undefined;
@@ -1276,6 +1281,12 @@ fn liveWindowFrame(wid: u32) ?window_mod.Window.Frame {
         .y = rect.origin.y,
         .width = rect.size.width,
         .height = rect.size.height,
+    };
+}
+
+fn seedObservedFrame(wid: u32, frame: window_mod.Window.Frame) void {
+    g_geometry.seedObserved(wid, frame) catch |err| {
+        log.warn("geometry: failed to seed observed frame wid={d}: {}", .{ wid, err });
     };
 }
 
@@ -1353,7 +1364,7 @@ const HideCtx = struct {
         const pos_x = park.x;
         const pos_y = park.y;
 
-        const ok = ax_mod.setWindowPosition(pid, wid, pos_x, pos_y);
+        const ok = setWindowPositionTracked(pid, wid, pos_x, pos_y, .workspace_park);
         log.debug("hide window wid={d} pid={d} ok={} x={d:.0} y={d:.0}", .{ wid, pid, ok, pos_x, pos_y });
         if (!ok and !self.hideFocusedFallback(pid, wid, pos_x, pos_y)) {
             log.warn("hide failed wid={d} pid={d}", .{ wid, pid });
@@ -1421,7 +1432,7 @@ const HideCtx = struct {
         const focused_wid = focusedWindowIdForPid(pid) orelse return false;
         if (focused_wid == failed_wid) return false;
 
-        const ok = ax_mod.setWindowPosition(pid, focused_wid, x, y);
+        const ok = setWindowPositionTracked(pid, focused_wid, x, y, .workspace_park);
         log.debug("hide fallback focused window failed_wid={d} focused_wid={d} pid={d} ok={} x={d:.0} y={d:.0}", .{
             failed_wid,
             focused_wid,
@@ -1490,6 +1501,7 @@ var g_displays: [workspace_mod.max_displays]DisplayInfo = undefined;
 var g_display_count: usize = 0;
 var g_bsp_split_mode: tiling.SplitMode = .auto;
 var g_tab_groups: tabgroup.TabGroupManager = undefined;
+var g_geometry: geometry_mod = undefined;
 var g_pending_role_windows: PendingRoleWindowMap = undefined;
 var g_deferred_window_candidates: DeferredWindowCandidateMap = undefined;
 var g_app_launch_retries: AppLaunchRetryMap = undefined;
@@ -1501,6 +1513,10 @@ var g_config_runtime: ?ConfigRuntime = null;
 var g_config_path: ?[:0]const u8 = null;
 var g_drag_preview: DragPreviewState = .{};
 var g_mouse_left_down = false;
+var g_mouse_down_location: c.CGPoint = .{ .x = 0, .y = 0 };
+var g_pointer_drag_candidate_wid: ?u32 = null;
+var g_pointer_drag_wid: ?u32 = null;
+var g_mouse_drag_event_emitted = false;
 var g_drag_reconcile_on_drop = false;
 /// PID of the last window we focused via bw_ax_focus_window. Used to detect
 /// same-process focus switches that need a delay for Electron compatibility.
@@ -1823,6 +1839,49 @@ fn cgWindowInfoVisible(info: c.CFDictionaryRef) bool {
     const ok = c.CFNumberGetValue(alpha_ref, c.kCFNumberCGFloatType, &alpha);
     if (ok == 0) return true;
     return alpha > 0.01;
+}
+
+/// Resolve the topmost managed layer-0 window under a pointer-down location.
+/// CG's list is front-to-back, so skipping unmanaged overlays still reaches
+/// the actual window below them. Binding the drag candidate here lets the
+/// first real leftMouseDragged event establish exact per-window ownership;
+/// a mouse button merely held elsewhere never authorizes geometry adoption.
+fn managedWindowAtPoint(point: c.CGPoint) ?u32 {
+    const options: cg_extra.CGWindowListOption =
+        cg_extra.kCGWindowListOptionOnScreenOnly | cg_extra.kCGWindowListExcludeDesktopElements;
+    const list = cg_extra.CGWindowListCopyWindowInfo(options, cg_extra.kCGNullWindowID) orelse return null;
+    defer c.CFRelease(@ptrCast(list));
+
+    const count = c.CFArrayGetCount(list);
+    std.debug.assert(count >= 0);
+    var i: c.CFIndex = 0;
+    while (i < count) : (i += 1) {
+        const info_any = c.CFArrayGetValueAtIndex(list, i) orelse continue;
+        const info: c.CFDictionaryRef = @ptrCast(info_any);
+        if (!cgWindowInfoVisible(info)) continue;
+
+        const layer_ref_any = c.CFDictionaryGetValue(info, cg_extra.kCGWindowLayer) orelse continue;
+        const layer_ref: c.CFNumberRef = @ptrCast(layer_ref_any);
+        var layer: i32 = 0;
+        if (c.CFNumberGetValue(layer_ref, c.kCFNumberSInt32Type, &layer) == 0 or layer != 0) continue;
+
+        const wid_ref_any = c.CFDictionaryGetValue(info, cg_extra.kCGWindowNumber) orelse continue;
+        const wid_ref: c.CFNumberRef = @ptrCast(wid_ref_any);
+        var wid: u32 = 0;
+        if (c.CFNumberGetValue(wid_ref, c.kCFNumberSInt32Type, &wid) == 0) continue;
+        if (g_store.get(wid) == null) continue;
+
+        const bounds_ref_any = c.CFDictionaryGetValue(info, cg_extra.kCGWindowBounds) orelse continue;
+        const bounds_ref: c.CFDictionaryRef = @ptrCast(bounds_ref_any);
+        var bounds: c.CGRect = std.mem.zeroes(c.CGRect);
+        if (!c.CGRectMakeWithDictionaryRepresentation(bounds_ref, &bounds)) continue;
+
+        const inside_x = point.x >= bounds.origin.x and point.x <= bounds.origin.x + bounds.size.width;
+        const inside_y = point.y >= bounds.origin.y and point.y <= bounds.origin.y + bounds.size.height;
+        if (inside_x and inside_y) return wid;
+    }
+
+    return null;
 }
 
 /// Get all AX-backed window IDs for an application PID.
@@ -2433,10 +2492,20 @@ fn hotkeyTapCallback(
     }
 
     if (event_type == c.kCGEventLeftMouseDown) {
+        g_mouse_down_location = cg_extra.CGEventGetLocation(event);
+        g_mouse_drag_event_emitted = false;
         bw_hotkey_mouse_down();
         return event;
     }
+    if (event_type == c.kCGEventLeftMouseDragged) {
+        if (!g_mouse_drag_event_emitted) {
+            g_mouse_drag_event_emitted = true;
+            bw_hotkey_mouse_dragged();
+        }
+        return event;
+    }
     if (event_type == c.kCGEventLeftMouseUp) {
+        g_mouse_drag_event_emitted = false;
         bw_hotkey_mouse_up();
         return event;
     }
@@ -2456,6 +2525,7 @@ fn setupHotkeyEventTap() void {
     const mask: c.CGEventMask =
         (@as(c.CGEventMask, 1) << @intCast(c.kCGEventKeyDown)) |
         (@as(c.CGEventMask, 1) << @intCast(c.kCGEventLeftMouseDown)) |
+        (@as(c.CGEventMask, 1) << @intCast(c.kCGEventLeftMouseDragged)) |
         (@as(c.CGEventMask, 1) << @intCast(c.kCGEventLeftMouseUp));
 
     g_tap_port = cg_extra.CGEventTapCreate(
@@ -2535,6 +2605,12 @@ fn bw_hotkey_mouse_down() void {
 /// Callback target for shim hotkey mouse up events.
 fn bw_hotkey_mouse_up() void {
     bw_emit_event(shim.BW_EVENT_MOUSE_UP, 0, 0);
+}
+
+/// Mark the first actual pointer-drag event separately from mouse-down. A
+/// click held while bobrwm retiles is not a user geometry change.
+fn bw_hotkey_mouse_dragged() void {
+    bw_emit_event(shim.BW_EVENT_MOUSE_DRAGGED, 0, 0);
 }
 
 /// Accept the keybind table from config. Stores a reference to caller-owned
@@ -2645,6 +2721,12 @@ pub fn main(init: std.process.Init.Minimal) !void {
     defer destroyAllTilingStates();
     g_tab_groups = tabgroup.TabGroupManager.init(g_allocator);
     defer g_tab_groups.deinit();
+    g_geometry = geometry_mod.init(g_allocator);
+    defer g_geometry.deinit();
+    g_geometry.ensureTotalCapacity(geometry_window_capacity) catch |err| {
+        log.err("geometry coordinator reserve failed: {}", .{err});
+        return err;
+    };
     g_pending_role_windows = PendingRoleWindowMap.init(g_allocator);
     defer g_pending_role_windows.deinit();
     g_pending_role_windows.ensureTotalCapacity(pending_role_window_capacity) catch |err| {
@@ -2820,6 +2902,9 @@ fn recoverFromEventOverflow() void {
     // Mouse-up may be the lost event. Abandon transient drag state rather than
     // leaving every later AX move classified as a user drag indefinitely.
     g_mouse_left_down = false;
+    g_pointer_drag_candidate_wid = null;
+    g_pointer_drag_wid = null;
+    g_geometry.clearIntents();
     g_drag_reconcile_on_drop = false;
     clearDragPreview();
 
@@ -2837,6 +2922,81 @@ fn recoverFromEventOverflow() void {
     requestOffscreenCleanup();
     requestRetileAllDisplays();
     refreshRolePolling();
+}
+
+/// Re-read WindowServer after AX notification delivery has settled. The
+/// immediate event handler can still see the prior frame, and some apps emit
+/// no follow-up notification after the physical geometry finally changes.
+fn reconcileDueGeometryObservations() void {
+    const now_ns = nanoTimestamp();
+    var due_wids: [geometry_window_capacity]u32 = undefined;
+    const due_count = g_geometry.collectDueResamples(now_ns, &due_wids);
+
+    for (due_wids[0..due_count]) |wid| {
+        if (g_pointer_drag_wid == wid) {
+            g_geometry.deferResample(wid, now_ns);
+            continue;
+        }
+
+        const observed = liveWindowFrame(wid) orelse {
+            if (g_geometry.get(wid)) |entry| {
+                if (entry.intent) |intent| {
+                    if (now_ns <= intent.settle_deadline_ns) {
+                        g_geometry.deferResample(wid, now_ns);
+                        continue;
+                    }
+                    if (reconcileDivergedGeometryIntent(wid, intent)) {
+                        g_geometry.forget(wid);
+                        continue;
+                    }
+                }
+            }
+            // No physical window exists after the ownership interval. Drop
+            // the sample state; cleanup/tab reconciliation owns any remaining
+            // store entry and a later write will create fresh provenance.
+            g_geometry.forget(wid);
+            continue;
+        };
+        const pending_intent = if (g_geometry.get(wid)) |entry| entry.intent else null;
+        switch (g_geometry.settle(wid, observed, now_ns)) {
+            .manager => log.debug("geometry: trailing sample manager-owned wid={d}", .{wid}),
+            .external => {
+                log.debug("geometry: trailing sample external wid={d}", .{wid});
+                if (pending_intent) |intent| {
+                    if (reconcileDivergedGeometryIntent(wid, intent)) continue;
+                }
+                handleExternalWindowGeometry(wid, observed);
+            },
+        }
+    }
+}
+
+/// An accepted AX write can target a native-tab ID that disappeared from the
+/// visible AX window set while the application simultaneously surfaced a new
+/// focused ID. Reconcile through the existing tab-aware focus path before
+/// retrying geometry; blindly reissuing the stale ID would loop forever.
+fn reconcileDivergedGeometryIntent(wid: u32, intent: geometry_mod.Intent) bool {
+    switch (intent.source) {
+        .tab_sync, .workspace_park, .exit_restore => return false,
+        .layout, .floating_restore, .user_command, .animation => {},
+    }
+
+    const win = g_store.get(wid) orelse return false;
+    if (!workspaceVisibleOnDisplay(win.workspace_id, win.display_id)) return false;
+    if (bw_is_window_on_screen(wid)) return false;
+
+    const focused_wid = focusedWindowIdForPid(win.pid) orelse return false;
+    if (focused_wid == wid) return false;
+
+    log.debug("geometry: divergent intent reconciling stale wid={d} focused_wid={d} pid={d} source={s}", .{
+        wid,
+        focused_wid,
+        win.pid,
+        @tagName(intent.source),
+    });
+    reconcileFocusedWindow(win.pid, focused_wid);
+    requestRetileDisplay(win.display_id);
+    return true;
 }
 
 /// Exit `[NSApp run]` cleanly by setting NSApplication's stop flag and posting
@@ -3023,6 +3183,7 @@ fn adoptWindow(ws: *workspace_mod.Workspace, win: window_mod.Window) !void {
 
     g_store.putAssumeCapacity(win);
     ws.addWindowAssumeCapacity(win.wid);
+    seedObservedFrame(win.wid, win.frame);
 }
 
 fn setTilingActive(workspace_id: u8, wid: u32) void {
@@ -3076,6 +3237,8 @@ fn replaceManagedWindowId(old_wid: u32, new_wid: u32, frame: window_mod.Window.F
         return false;
     };
     g_store.remove(old_wid);
+    g_geometry.forget(old_wid);
+    seedObservedFrame(new_wid, frame);
     ax_mod.invalidateWindow(old_wid);
     log.info("window id replaced old={d} new={d} pid={d} workspace={d} display={d}", .{
         old_wid,
@@ -3454,6 +3617,7 @@ fn handleEvent(ev: *const event_mod.Event) void {
             log.info("space changed", .{});
         },
         .role_poll_tick => {
+            reconcileDueGeometryObservations();
             if (processDueDisplayResettle()) return;
             const promoted_pending = processPendingRoleWindows();
             const promoted_deferred = processDeferredWindowCandidates();
@@ -3466,10 +3630,22 @@ fn handleEvent(ev: *const event_mod.Event) void {
         },
         .mouse_down => {
             g_mouse_left_down = true;
+            g_pointer_drag_candidate_wid = managedWindowAtPoint(g_mouse_down_location);
+            g_pointer_drag_wid = null;
             g_drag_reconcile_on_drop = false;
+        },
+        .mouse_dragged => {
+            if (g_mouse_left_down and g_pointer_drag_wid == null) {
+                g_pointer_drag_wid = g_pointer_drag_candidate_wid;
+                if (g_pointer_drag_wid) |wid| {
+                    log.debug("geometry: pointer drag claimed wid={d}", .{wid});
+                }
+            }
         },
         .mouse_up => {
             g_mouse_left_down = false;
+            g_pointer_drag_candidate_wid = null;
+            g_pointer_drag_wid = null;
             const drag_needs_reconcile_on_drop = g_drag_reconcile_on_drop;
             defer g_drag_reconcile_on_drop = false;
             if (g_drag_preview.source_wid) |source_wid| {
@@ -3494,7 +3670,7 @@ fn handleEvent(ev: *const event_mod.Event) void {
             // retile per tick.
             if (g_animator.isAnimatingWindow(ev.wid)) return;
 
-            if (inWorkspaceTransition() and !g_mouse_left_down) {
+            if (inWorkspaceTransition() and g_pointer_drag_wid != ev.wid) {
                 if (ev.kind == .window_resized) {
                     clearDragPreview();
                 }
@@ -3505,7 +3681,29 @@ fn handleEvent(ev: *const event_mod.Event) void {
                 if (ev.kind == .window_moved) "moved" else "resized",
                 ev.wid,
             });
-            if (updateWindowDisplayAssignment(ev.wid)) {
+
+            const observed = liveWindowFrame(ev.wid) orelse return;
+            const owner = g_geometry.observe(
+                ev.wid,
+                observed,
+                nanoTimestamp(),
+                g_pointer_drag_wid,
+            ) catch |err| {
+                log.warn("geometry: failed to record observation wid={d}: {}", .{ ev.wid, err });
+                return;
+            };
+            refreshRolePolling();
+
+            if (owner == .manager) {
+                log.debug("geometry: ignored manager echo wid={d}", .{ev.wid});
+                return;
+            }
+            if (owner == .external) {
+                handleExternalWindowGeometry(ev.wid, observed);
+                return;
+            }
+
+            if (updateDraggedWindowGeometry(ev.wid, observed)) {
                 retile();
                 return;
             }
@@ -3517,7 +3715,7 @@ fn handleEvent(ev: *const event_mod.Event) void {
                 }
             }
             checkTabDragOut(ev.pid, ev.wid);
-            if (g_mouse_left_down) {
+            if (g_pointer_drag_wid == ev.wid) {
                 if (g_store.get(ev.wid)) |win| {
                     if (win.mode == .tiled and !win.is_fullscreen and workspaceVisibleOnDisplay(win.workspace_id, win.display_id)) {
                         g_drag_reconcile_on_drop = true;
@@ -3525,10 +3723,7 @@ fn handleEvent(ev: *const event_mod.Event) void {
                 }
             }
             if (ev.kind == .window_moved) {
-                // Ignore synthetic move events generated by our own retile calls.
-                if (g_mouse_left_down) {
-                    updateWindowMovePreview(ev.wid);
-                }
+                updateWindowMovePreview(ev.wid);
             } else {
                 clearDragPreview();
             }
@@ -3653,7 +3848,7 @@ fn toggleWindowFullscreen(wid: u32) void {
 
     if (restore_to) |target| {
         if (g_store.get(visible_wid)) |visible| {
-            if (applyWindowFrame(visible.pid, visible_wid, visible.frame, target, false)) {
+            if (applyWindowFrame(visible.pid, visible_wid, visible.frame, target, false, .floating_restore)) {
                 var updated = visible;
                 updated.frame = target;
                 g_store.put(updated) catch {};
@@ -3682,7 +3877,10 @@ fn centerFloatingWindow(wid: u32) void {
 
     const size = liveWindowFrame(wid) orelse win.frame;
     const target = centeredFrame(size.width, size.height, display);
-    _ = ax_mod.setWindowFrame(win.pid, wid, target.x, target.y, target.width, target.height);
+    if (!setWindowFrameTracked(win.pid, wid, target, .user_command)) {
+        log.warn("center floating: frame write rejected wid={d}", .{wid});
+        return;
+    }
     win.frame = target;
     win.float_frame = target;
     g_store.put(win) catch {};
@@ -3712,7 +3910,8 @@ fn refreshRolePolling() void {
         g_focus_retries.count() > 0 or
         g_deferred_follow_focus != null or
         g_display_resettle_at_s != 0 or
-        g_event_overflow_recovery_pending;
+        g_event_overflow_recovery_pending or
+        g_geometry.hasPendingResamples();
     setRolePolling(has_pending);
 }
 
@@ -3918,8 +4117,16 @@ fn trackPendingRoleWindow(pid: i32, wid: u32, workspace_id: u8, display_id: u32)
 fn untrackPendingRoleWindow(wid: u32) void {
     std.debug.assert(wid != 0);
     if (g_pending_role_windows.remove(wid)) {
+        forgetGeometryIfUnmanaged(wid);
         refreshRolePolling();
     }
+}
+
+fn forgetGeometryIfUnmanaged(wid: u32) void {
+    if (g_store.get(wid) != null) return;
+    if (g_pending_role_windows.contains(wid)) return;
+    if (g_deferred_window_candidates.contains(wid)) return;
+    g_geometry.forget(wid);
 }
 
 /// Remove all entries matching `pid` from a wid-keyed map whose values
@@ -3944,6 +4151,7 @@ fn removeEntriesForPid(comptime V: type, map: *std.AutoHashMap(u32, V), pid: i32
         for (remove_batch[0..remove_count]) |wid| {
             if (map.remove(wid)) {
                 removed_any = true;
+                forgetGeometryIfUnmanaged(wid);
             }
         }
 
@@ -3997,6 +4205,7 @@ fn trackDeferredWindowCandidate(pid: i32, wid: u32, workspace_id: u8, display_id
 fn untrackDeferredWindowCandidate(wid: u32) void {
     std.debug.assert(wid != 0);
     if (g_deferred_window_candidates.remove(wid)) {
+        forgetGeometryIfUnmanaged(wid);
         refreshRolePolling();
     }
 }
@@ -4083,6 +4292,7 @@ fn processPendingRoleWindows() bool {
 
     for (remove_wids[0..remove_count]) |wid| {
         _ = g_pending_role_windows.remove(wid);
+        forgetGeometryIfUnmanaged(wid);
     }
     refreshRolePolling();
 
@@ -4215,6 +4425,7 @@ fn processDeferredWindowCandidates() bool {
 
     for (remove_wids[0..remove_count]) |wid| {
         _ = g_deferred_window_candidates.remove(wid);
+        forgetGeometryIfUnmanaged(wid);
     }
 
     if (truncated) {
@@ -4234,6 +4445,7 @@ fn processDeferredWindowCandidates() bool {
             // Managed (or resolved another way, e.g. adopted into a tab
             // group, which stores the window without returning true).
             _ = g_deferred_window_candidates.remove(candidate.wid);
+            forgetGeometryIfUnmanaged(candidate.wid);
             added_any = true;
         } else if (g_deferred_window_candidates.getPtr(candidate.wid)) |entry| {
             // Promotion failed and re-deferred (e.g. bounds still unsettled).
@@ -4241,6 +4453,7 @@ fn processDeferredWindowCandidates() bool {
             // never settle expires instead of cycling forever.
             if (entry.attempts_remaining == 0) {
                 _ = g_deferred_window_candidates.remove(candidate.wid);
+                forgetGeometryIfUnmanaged(candidate.wid);
                 log.info("deferred-window: giving up pid={d} wid={d} after {d}ms with unsettled bounds", .{
                     candidate.pid,
                     candidate.wid,
@@ -4695,6 +4908,7 @@ fn refreshTabGroupActiveTabs() void {
                 .workspace_id = leader.workspace_id,
                 .display_id = leader.display_id,
             });
+            seedObservedFrame(move.selected, group.canonical_frame);
         }
 
         log.debug("tab group {d} active tab {d} → {d} (tab bar)", .{
@@ -4787,6 +5001,7 @@ fn joinTabGroup(pid: i32, sibling_wid: u32, new_wid: u32, new_frame: window_mod.
         .workspace_id = sibling.workspace_id,
         .display_id = sibling.display_id,
     });
+    seedObservedFrame(new_wid, new_frame);
 
     const leader = g_tab_groups.resolveLeader(sibling_wid);
     ws.recordFocus(leader);
@@ -4801,6 +5016,7 @@ fn joinTabGroup(pid: i32, sibling_wid: u32, new_wid: u32, new_frame: window_mod.
 
 fn removeWindow(wid: u32) void {
     g_animator.cancel(wid);
+    g_geometry.forget(wid);
     ax_mod.invalidateWindow(wid);
     untrackPendingRoleWindow(wid);
     untrackDeferredWindowCandidate(wid);
@@ -5212,31 +5428,15 @@ fn adoptWindowAsBackgroundTab(win: window_mod.Window) tabgroup.detect.OffscreenO
     return .adopt;
 }
 
-/// Updates `display_id` when a user-dragged window crosses monitors.
+/// Adopt geometry from the exact window claimed by a real pointer drag.
 /// Returns true when display ownership changed and callers should retile.
-fn updateWindowDisplayAssignment(wid: u32) bool {
-    // AX move/resize notifications also echo every frame bobrwm writes. The
-    // corresponding SkyLight bounds can still describe the previous frame,
-    // so accepting them here corrupts the stored layout target and makes the
-    // next placement look like a no-op. Only a live pointer drag transfers
-    // geometry ownership from the layout back to the user.
-    if (!g_mouse_left_down) return false;
-
+fn updateDraggedWindowGeometry(wid: u32, frame: window_mod.Window.Frame) bool {
+    if (g_pointer_drag_wid != wid) return false;
     var win = g_store.get(wid) orelse return false;
-    const sky = g_sky orelse return false;
-
-    var rect: skylight.CGRect = undefined;
-    if (sky.getWindowBounds(sky.mainConnectionID(), wid, &rect) != 0) return false;
-
-    const frame: window_mod.Window.Frame = .{
-        .x = rect.origin.x,
-        .y = rect.origin.y,
-        .width = rect.size.width,
-        .height = rect.size.height,
-    };
     const next_display_id = displayIdForFrame(frame);
     if (next_display_id == win.display_id) {
         win.frame = frame;
+        if (win.mode == .floating and !win.is_fullscreen) win.float_frame = frame;
         g_store.put(win) catch {};
         return false;
     }
@@ -5251,6 +5451,7 @@ fn updateWindowDisplayAssignment(wid: u32) bool {
 
     removeFromTiling(win.workspace_id, wid);
     win.frame = frame;
+    if (win.mode == .floating and !win.is_fullscreen) win.float_frame = frame;
     win.display_id = next_display_id;
     g_store.put(win) catch return false;
     if (win.mode == .tiled) {
@@ -5263,6 +5464,44 @@ fn updateWindowDisplayAssignment(wid: u32) bool {
     _ = maybeSetFocusedDisplayForWindow(win, .drag);
     log.info("window moved to display wid={d} display={d}", .{ wid, win.display_id });
     return true;
+}
+
+/// Apply ownership policy to geometry changed without an active pointer drag.
+/// Layout-owned windows are repaired from their desired frame; floating
+/// windows accept same-display application changes as their new restore frame.
+fn handleExternalWindowGeometry(wid: u32, frame: window_mod.Window.Frame) void {
+    var win = g_store.get(wid) orelse return;
+
+    if (!workspaceVisibleOnDisplay(win.workspace_id, win.display_id)) {
+        // Parked windows intentionally differ from their layout frame while
+        // hidden. Never let their trailing AX echoes retile the visible
+        // workspace or adopt the parked position as floating restore state.
+        log.debug("geometry: ignored external sample for hidden wid={d}", .{wid});
+        return;
+    }
+
+    if (win.mode == .tiled or win.is_fullscreen) {
+        log.debug("geometry: external layout drift wid={d}; scheduling retile", .{wid});
+        requestRetileDisplay(win.display_id);
+        return;
+    }
+
+    const next_display_id = displayIdForFrame(frame);
+    if (next_display_id != win.display_id) {
+        // Workspace/display ownership changes only through the pointer-drag or
+        // explicit move paths, which update every correlated data structure.
+        // Accepting just the frame here would strand the floating window on a
+        // display where its workspace is not visible.
+        log.debug("geometry: external floating cross-display drift wid={d}; scheduling restore", .{wid});
+        requestRetileDisplay(win.display_id);
+        return;
+    }
+
+    win.frame = frame;
+    win.float_frame = frame;
+    g_store.put(win) catch |err| {
+        log.warn("geometry: failed to store external floating frame wid={d}: {}", .{ wid, err });
+    };
 }
 
 /// Lowest workspace id (1-based) not yet claimed as active on a display.
@@ -5427,9 +5666,21 @@ fn parkHiddenWorkspaceWindows() void {
 /// and clamped fullscreen sizes must be re-asserted even when the store
 /// believes they already match. Returns whether the final AX write was
 /// accepted so callers can avoid recording frames that were never applied.
-fn applyWindowFrame(pid: i32, wid: u32, current: window_mod.Window.Frame, target: window_mod.Window.Frame, two_pass: bool) bool {
-    if (!two_pass and current.sizeApproxEqual(target, window_mod.Window.Frame.tolerance)) {
-        return ax_mod.setWindowPosition(pid, wid, target.x, target.y);
+fn applyWindowFrame(
+    pid: i32,
+    wid: u32,
+    current: window_mod.Window.Frame,
+    target: window_mod.Window.Frame,
+    two_pass: bool,
+    source: geometry_mod.IntentSource,
+) bool {
+    // Choose position-only from observed physical geometry, not the stored
+    // target. External resize drift can leave the store already equal to the
+    // desired layout while WindowServer has a different size; consulting the
+    // store there would issue a move and permanently leave the bad size.
+    const physical = if (g_geometry.get(wid)) |entry| entry.observed orelse current else current;
+    if (!two_pass and physical.sizeApproxEqual(target, window_mod.Window.Frame.tolerance)) {
+        return setWindowPositionTracked(pid, wid, target.x, target.y, source);
     }
 
     var ok = false;
@@ -5437,7 +5688,61 @@ fn applyWindowFrame(pid: i32, wid: u32, current: window_mod.Window.Frame, target
     for (0..passes) |_| {
         ok = ax_mod.setWindowFrame(pid, wid, target.x, target.y, target.width, target.height);
     }
+    if (ok) recordFrameIntent(wid, target, source);
     return ok;
+}
+
+fn setWindowFrameTracked(
+    pid: i32,
+    wid: u32,
+    target: window_mod.Window.Frame,
+    source: geometry_mod.IntentSource,
+) bool {
+    const ok = ax_mod.setWindowFrame(pid, wid, target.x, target.y, target.width, target.height);
+    if (ok) recordFrameIntent(wid, target, source);
+    return ok;
+}
+
+fn setWindowPositionTracked(
+    pid: i32,
+    wid: u32,
+    x: f64,
+    y: f64,
+    source: geometry_mod.IntentSource,
+) bool {
+    const ok = ax_mod.setWindowPosition(pid, wid, x, y);
+    if (ok) {
+        _ = g_geometry.recordPositionAccepted(wid, x, y, source, nanoTimestamp()) catch |err| {
+            log.warn("geometry: failed to record position intent wid={d}: {}", .{ wid, err });
+            return ok;
+        };
+        refreshRolePolling();
+    }
+    return ok;
+}
+
+fn recordFrameIntent(wid: u32, target: window_mod.Window.Frame, source: geometry_mod.IntentSource) void {
+    _ = g_geometry.recordFrameAccepted(wid, target, source, nanoTimestamp()) catch |err| {
+        log.warn("geometry: failed to record frame intent wid={d}: {}", .{ wid, err });
+        return;
+    };
+    refreshRolePolling();
+}
+
+fn recordAnimationIntent(wid: u32, target: window_mod.Window.Frame) void {
+    const animation_ns = @as(i128, @intCast(g_config.animation.duration_ms)) * std.time.ns_per_ms;
+    const settle_ns = animation_ns + geometry_mod.default_settle_interval_ns;
+    _ = g_geometry.recordFrameAcceptedFor(
+        wid,
+        target,
+        .animation,
+        nanoTimestamp(),
+        settle_ns,
+    ) catch |err| {
+        log.warn("geometry: failed to record animation intent wid={d}: {}", .{ wid, err });
+        return;
+    };
+    refreshRolePolling();
 }
 
 fn clampFrameToDisplay(frame: window_mod.Window.Frame, display: shim.bw_frame) window_mod.Window.Frame {
@@ -5501,8 +5806,8 @@ fn restoreFloatingWindows(ws_id: u8, display_id: u32, display: shim.bw_frame, co
         // re-enter here forever, but write two-pass because macOS clamps
         // fullscreen sizes mid-flight.
         if (leader.is_fullscreen) {
-            if (!framesEqual(win.frame, content)) {
-                if (applyWindowFrame(win.pid, wid, win.frame, content, true)) {
+            if (!framesEqual(win.frame, content) or g_geometry.needsRepair(wid, content, nanoTimestamp())) {
+                if (applyWindowFrame(win.pid, wid, win.frame, content, true, .floating_restore)) {
                     win.frame = content;
                     g_store.put(win) catch {};
                 }
@@ -5528,7 +5833,10 @@ fn restoreFloatingWindows(ws_id: u8, display_id: u32, display: shim.bw_frame, co
         else
             centeredFrame(rect.size.width, rect.size.height, display);
 
-        _ = ax_mod.setWindowFrame(win.pid, wid, target.x, target.y, target.width, target.height);
+        if (!setWindowFrameTracked(win.pid, wid, target, .floating_restore)) {
+            log.warn("restore floating: frame write rejected wid={d}", .{wid});
+            continue;
+        }
         win.frame = target;
         g_store.put(win) catch {};
         applyFrameToTabGroup(leader_wid, target);
@@ -5551,9 +5859,9 @@ fn applyFrameToTabGroup(leader_wid: u32, frame: window_mod.Window.Frame) void {
     g.canonical_frame = frame;
     for (g.members.items) |member_wid| {
         const member = g_store.get(member_wid) orelse continue;
-        if (framesEqual(member.frame, frame)) continue;
+        if (framesEqual(member.frame, frame) and !g_geometry.needsRepair(member_wid, frame, nanoTimestamp())) continue;
 
-        if (applyWindowFrame(member.pid, member_wid, member.frame, frame, false)) {
+        if (applyWindowFrame(member.pid, member_wid, member.frame, frame, false, .tab_sync)) {
             var updated = member;
             updated.frame = frame;
             g_store.put(updated) catch {};
@@ -5623,19 +5931,22 @@ fn retileDisplay(display_id: u32) void {
         // Fullscreen windows fill the outer-gap-inset frame, skipping BSP splits and inner gaps
         const target_frame = if (win.is_fullscreen) frame else entry.frame;
 
-        if (!framesEqual(visible.frame, target_frame)) {
+        if (!framesEqual(visible.frame, target_frame) or
+            g_geometry.needsRepair(visible_wid, target_frame, nanoTimestamp()))
+        {
             // Fullscreen windows are never animated: macOS clamps their size
             // mid-flight and they need the two-pass set below to land on the
             // exact display frame.
             var applied = true;
             if (g_config.animation.enabled and !win.is_fullscreen) {
                 applied = g_animator.animate(visible.pid, visible_wid, visible.frame, target_frame);
+                if (applied) recordAnimationIntent(visible_wid, target_frame);
                 ensureAnimatorTimer();
             } else {
                 // The window may have entered fullscreen mid-animation; stop
                 // the in-flight animation so it doesn't fight the placement.
                 g_animator.cancel(visible_wid);
-                applied = applyWindowFrame(visible.pid, visible_wid, visible.frame, target_frame, win.is_fullscreen);
+                applied = applyWindowFrame(visible.pid, visible_wid, visible.frame, target_frame, win.is_fullscreen, .layout);
             }
 
             // Record the target only when the write was accepted (animation
@@ -5684,7 +5995,13 @@ fn restoreAllWindows() void {
                 const h = if (win.frame.height > 1) win.frame.height else display.h * 0.5;
                 const x = display.x + (display.w - w) / 2.0;
                 const y = display.y + (display.h - h) / 2.0;
-                _ = ax_mod.setWindowFrame(win.pid, wid, x, y, w, h);
+                const target: window_mod.Window.Frame = .{
+                    .x = x,
+                    .y = y,
+                    .width = w,
+                    .height = h,
+                };
+                _ = setWindowFrameTracked(win.pid, wid, target, .exit_restore);
             }
         }
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -54,11 +54,9 @@ pub const std_options = std.Options{
 
 const log = std.log.scoped(.bobrwm);
 
-// Lock-free SPSC ring buffer
-//
-// Single-producer (main thread) only. All emitters must run on the
-// main thread / main queue. The consumer is bw_drain_events, also on
-// the main run-loop.
+// Fixed-capacity event ring. Producers are serialized by g_ring_lock because
+// AX callbacks run on the observer thread while AppKit and hotkey callbacks run
+// on the main thread. The main-runloop consumer remains lock-free.
 
 const EventRing = struct {
     const capacity = 1024;
@@ -66,6 +64,7 @@ const EventRing = struct {
     buf: [capacity]event_mod.Event = undefined,
     head: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
     tail: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    overflowed: std.atomic.Value(bool) = .init(false),
     dropped: usize = 0,
 
     fn push(self: *EventRing, ev: event_mod.Event) void {
@@ -73,6 +72,7 @@ const EventRing = struct {
         const next = (t + 1) % capacity;
         if (next == self.head.load(.acquire)) {
             self.dropped += 1;
+            self.overflowed.store(true, .release);
             log.err("event ring full, dropped event kind={s} pid={d} wid={d} total_dropped={d}", .{
                 @tagName(ev.kind), ev.pid, ev.wid, self.dropped,
             });
@@ -88,6 +88,10 @@ const EventRing = struct {
         const ev = self.buf[h];
         self.head.store((h + 1) % capacity, .release);
         return ev;
+    }
+
+    fn takeOverflowed(self: *EventRing) bool {
+        return self.overflowed.swap(false, .acq_rel);
     }
 };
 
@@ -1570,6 +1574,8 @@ var g_retile_requested_all_displays = false;
 var g_retile_dirty_display_ids: [workspace_mod.max_displays]u32 = [_]u32{0} ** workspace_mod.max_displays;
 var g_retile_dirty_display_count: usize = 0;
 var g_event_drain_active = false;
+var g_event_overflow_recovery_pending = false;
+var g_on_screen_truncation_logged = false;
 var g_cleanup_pending_offscreen = false;
 var g_cleanup_pending_pids: [cleanup_pid_capacity_per_drain]i32 = undefined;
 var g_cleanup_pending_pid_count: usize = 0;
@@ -1634,7 +1640,10 @@ fn requestCleanupForPid(pid: i32) void {
     }
 
     if (g_cleanup_pending_pid_count >= g_cleanup_pending_pids.len) {
-        log.warn("cleanup: pid queue saturated, skipping pid={d}", .{pid});
+        log.warn("cleanup: pid queue saturated, scheduling broad reconciliation pid={d}", .{pid});
+        g_event_overflow_recovery_pending = true;
+        g_cleanup_pending_offscreen = true;
+        refreshRolePolling();
         return;
     }
 
@@ -1865,16 +1874,21 @@ fn cgWindowInfoVisible(info: c.CFDictionaryRef) bool {
 
 /// Get all AX-backed window IDs for an application PID.
 /// Includes windows that may not currently be visible on screen.
-fn bw_get_app_window_ids(pid: i32, out: []u32) usize {
-    if (out.len == 0) return 0;
+const BoundedSnapshotResult = struct {
+    count: usize,
+    truncated: bool,
+};
+
+fn bw_get_app_window_ids(pid: i32, out: []u32) BoundedSnapshotResult {
+    if (out.len == 0) return .{ .count = 0, .truncated = true };
 
     std.debug.assert(pid > 0);
 
     const out_buf = out;
-    const app = c.AXUIElementCreateApplication(pid) orelse return 0;
+    const app = c.AXUIElementCreateApplication(pid) orelse return .{ .count = 0, .truncated = false };
     defer c.CFRelease(@ptrCast(app));
 
-    const ax = ensureAxStrings() orelse return 0;
+    const ax = ensureAxStrings() orelse return .{ .count = 0, .truncated = false };
     const windows_attr = ax.windows_attr;
 
     var windows: c.CFArrayRef = null;
@@ -1883,8 +1897,8 @@ fn bw_get_app_window_ids(pid: i32, out: []u32) usize {
         windows_attr,
         @ptrCast(&windows),
     );
-    if (err != c.kAXErrorSuccess or windows == null) return 0;
-    const windows_ref = windows orelse return 0;
+    if (err != c.kAXErrorSuccess or windows == null) return .{ .count = 0, .truncated = false };
+    const windows_ref = windows orelse return .{ .count = 0, .truncated = false };
     defer c.CFRelease(@ptrCast(windows_ref));
 
     var written: usize = 0;
@@ -1892,19 +1906,24 @@ fn bw_get_app_window_ids(pid: i32, out: []u32) usize {
     std.debug.assert(total >= 0);
 
     var i: c.CFIndex = 0;
-    while (i < total and written < out_buf.len) : (i += 1) {
+    var truncated = false;
+    while (i < total) : (i += 1) {
         const win_any = c.CFArrayGetValueAtIndex(windows_ref, i) orelse continue;
         const win: c.AXUIElementRef = @ptrCast(win_any);
 
         var wid: u32 = 0;
         if (_AXUIElementGetWindow(win, &wid) == c.kAXErrorSuccess and wid != 0) {
+            if (written == out_buf.len) {
+                truncated = true;
+                break;
+            }
             out_buf[written] = wid;
             written += 1;
         }
     }
 
     std.debug.assert(written <= out_buf.len);
-    return @intCast(written);
+    return .{ .count = written, .truncated = truncated };
 }
 
 fn isRegularActivationApp(pid: i32) bool {
@@ -2167,13 +2186,14 @@ fn bw_window_manage_state(pid: i32, wid: u32) u8 {
 /// share the CGWindowList but have Prohibited activation policy. Caching the
 /// accept/reject decision per PID avoids an ObjC message send for every window
 /// belonging to the same rejected process.
-fn bw_discover_windows(out: []shim.bw_window_info) usize {
-    if (out.len == 0) return 0;
+fn bw_discover_windows(out: []shim.bw_window_info) BoundedSnapshotResult {
+    if (out.len == 0) return .{ .count = 0, .truncated = true };
     const out_buf = out;
 
     const options: cg_extra.CGWindowListOption =
         cg_extra.kCGWindowListOptionOnScreenOnly | cg_extra.kCGWindowListExcludeDesktopElements;
-    const window_list = cg_extra.CGWindowListCopyWindowInfo(options, cg_extra.kCGNullWindowID) orelse return 0;
+    const window_list = cg_extra.CGWindowListCopyWindowInfo(options, cg_extra.kCGNullWindowID) orelse
+        return .{ .count = 0, .truncated = false };
     defer c.CFRelease(@ptrCast(window_list));
 
     const total = c.CFArrayGetCount(window_list);
@@ -2187,8 +2207,9 @@ fn bw_discover_windows(out: []shim.bw_window_info) usize {
     var rejected_pid_count: usize = 0;
 
     var count: usize = 0;
+    var truncated = false;
     var i: c.CFIndex = 0;
-    while (i < total and count < out_buf.len) : (i += 1) {
+    while (i < total) : (i += 1) {
         const info_any = c.CFArrayGetValueAtIndex(window_list, i) orelse continue;
         const info: c.CFDictionaryRef = @ptrCast(info_any);
 
@@ -2234,6 +2255,11 @@ fn bw_discover_windows(out: []shim.bw_window_info) usize {
         }
         if (bounds.size.width < 1 or bounds.size.height < 1) continue;
 
+        if (count == out_buf.len) {
+            truncated = true;
+            break;
+        }
+
         out_buf[count] = .{
             .wid = wid,
             .pid = pid,
@@ -2246,7 +2272,7 @@ fn bw_discover_windows(out: []shim.bw_window_info) usize {
     }
 
     std.debug.assert(count <= out_buf.len);
-    return @intCast(count);
+    return .{ .count = count, .truncated = truncated };
 }
 
 fn pidInCache(pid: i32, cache: []const i32, count: usize) bool {
@@ -2777,6 +2803,12 @@ fn bw_drain_events() void {
     }
     drainIpcRequests();
 
+    if (g_ring.takeOverflowed()) {
+        g_event_overflow_recovery_pending = true;
+        refreshRolePolling();
+    }
+    recoverFromEventOverflow();
+
     // Flush retile BEFORE cleanup so windows are at their layout positions
     // when cleanup checks on-screen status. Without this, cleanup sees
     // corner-parked windows and incorrectly removes them as ghosts.
@@ -2801,6 +2833,39 @@ fn bw_drain_events() void {
     if (g_shutdown_requested.load(.acquire)) {
         gracefulStopNSApp();
     }
+}
+
+/// A dropped event has unknown semantics, so recover from authoritative OS
+/// state instead of guessing which individual mutation was lost. Cleanup is
+/// deferred through workspace transitions because parked windows are expected
+/// to be off-screen during that interval.
+fn recoverFromEventOverflow() void {
+    if (!g_event_overflow_recovery_pending) return;
+    if (g_workspace_transition.isActive()) return;
+
+    g_event_overflow_recovery_pending = false;
+    log.warn("event overflow: reconciling window, app, focus, and frame state", .{});
+
+    // Mouse-up may be the lost event. Abandon transient drag state rather than
+    // leaving every later AX move classified as a user drag indefinitely.
+    g_mouse_left_down = false;
+    g_drag_reconcile_on_drop = false;
+    clearDragPreview();
+
+    _ = removeStoppedAppWindows();
+    discoverWindows();
+    refreshTabGroupActiveTabs();
+    reconcileVisibleFramesFromWindowServer();
+
+    if (frontmostApplicationPid()) |pid| {
+        if (focusedWindowIdForPid(pid)) |wid| {
+            reconcileFocusedWindow(pid, wid);
+        }
+        requestCleanupForPid(pid);
+    }
+    requestOffscreenCleanup();
+    requestRetileAllDisplays();
+    refreshRolePolling();
 }
 
 /// Exit `[NSApp run]` cleanly by setting NSApplication's stop flag and posting
@@ -3746,7 +3811,8 @@ fn refreshRolePolling() void {
         g_app_launch_retries.count() > 0 or
         g_focus_retries.count() > 0 or
         g_deferred_follow_focus != null or
-        g_display_resettle_at_s != 0;
+        g_display_resettle_at_s != 0 or
+        g_event_overflow_recovery_pending;
     setRolePolling(has_pending);
 }
 
@@ -4293,14 +4359,17 @@ fn processDeferredWindowCandidates() bool {
 
 fn discoverWindows() void {
     var buf: [256]shim.bw_window_info = undefined;
-    const count = bw_discover_windows(&buf);
+    const discovery = bw_discover_windows(&buf);
+    if (discovery.truncated) {
+        log.warn("window discovery truncated limit={d}; excess windows remain unmanaged", .{buf.len});
+    }
     var observed_pids: [128]i32 = undefined;
     var observed_pid_count: usize = 0;
 
     // Sort windows by current x-position so the BSP tree order matches
     // their on-screen placement. Without this, windows discovered in
     // arbitrary order get swapped to the opposite side on the first retile.
-    const slice = buf[0..count];
+    const slice = buf[0..discovery.count];
     std.mem.sortUnstable(shim.bw_window_info, slice, {}, struct {
         fn lessThan(_: void, a: shim.bw_window_info, b: shim.bw_window_info) bool {
             return a.x < b.x;
@@ -4395,6 +4464,7 @@ fn discoverWindows() void {
 const OnScreenWindows = struct {
     wids: [512]u32 = undefined,
     count: usize = 0,
+    truncated: bool = false,
 
     fn snapshot() OnScreenWindows {
         var self: OnScreenWindows = .{};
@@ -4407,7 +4477,7 @@ const OnScreenWindows = struct {
         const total = c.CFArrayGetCount(list);
         std.debug.assert(total >= 0);
         var i: c.CFIndex = 0;
-        while (i < total and self.count < self.wids.len) : (i += 1) {
+        while (i < total) : (i += 1) {
             const info_any = c.CFArrayGetValueAtIndex(list, i) orelse continue;
             const info: c.CFDictionaryRef = @ptrCast(info_any);
             const wid_ref_any = c.CFDictionaryGetValue(info, cg_extra.kCGWindowNumber) orelse continue;
@@ -4416,6 +4486,15 @@ const OnScreenWindows = struct {
             var wid: u32 = 0;
             if (c.CFNumberGetValue(wid_ref, c.kCFNumberSInt32Type, &wid) == 0) continue;
             if (!cgWindowInfoVisible(info)) continue;
+
+            if (self.count == self.wids.len) {
+                self.truncated = true;
+                if (!g_on_screen_truncation_logged) {
+                    log.warn("on-screen window snapshot truncated limit={d}", .{self.wids.len});
+                    g_on_screen_truncation_logged = true;
+                }
+                break;
+            }
 
             self.wids[self.count] = wid;
             self.count += 1;
@@ -4438,14 +4517,18 @@ fn tabCandidates(
     pid: i32,
     on_screen: *const OnScreenWindows,
     out: []tabgroup.detect.Candidate,
-) usize {
+) BoundedSnapshotResult {
     std.debug.assert(pid > 0);
 
     var count: usize = 0;
+    var truncated = false;
     var it = g_store.windows.valueIterator();
     while (it.next()) |win| {
-        if (count == out.len) break;
         if (win.pid != pid) continue;
+        if (count == out.len) {
+            truncated = true;
+            break;
+        }
 
         const on_visible_workspace = workspaceVisibleOnDisplay(win.workspace_id, win.display_id);
         out[count] = .{
@@ -4457,7 +4540,7 @@ fn tabCandidates(
         };
         count += 1;
     }
-    return count;
+    return .{ .count = count, .truncated = truncated };
 }
 
 /// Snapshot the windows an application exposes in its AX window list.
@@ -4465,15 +4548,19 @@ fn appWindowSnapshot(
     pid: i32,
     on_screen: *const OnScreenWindows,
     out: []tabgroup.detect.AppWindow,
-) usize {
+) BoundedSnapshotResult {
     std.debug.assert(pid > 0);
 
     var ax_wids: [128]u32 = undefined;
-    const ax_count = bw_get_app_window_ids(pid, &ax_wids);
+    const ax_snapshot = bw_get_app_window_ids(pid, &ax_wids);
 
     var count: usize = 0;
-    for (ax_wids[0..ax_count]) |ax_wid| {
-        if (count == out.len) break;
+    var truncated = ax_snapshot.truncated;
+    for (ax_wids[0..ax_snapshot.count]) |ax_wid| {
+        if (count == out.len) {
+            truncated = true;
+            break;
+        }
         out[count] = .{
             .wid = ax_wid,
             .live_frame = liveWindowFrame(ax_wid),
@@ -4490,7 +4577,7 @@ fn appWindowSnapshot(
         });
         count += 1;
     }
-    return count;
+    return .{ .count = count, .truncated = truncated };
 }
 
 fn addNewWindowManagedWithAssignment(pid: i32, wid: u32, workspace_id: u8, assigned_display_id: u32) bool {
@@ -4654,15 +4741,18 @@ fn refreshTabGroupActiveTabs() void {
     if (g_tab_groups.groups.count() == 0) return;
 
     const on_screen = OnScreenWindows.snapshot();
+    if (on_screen.truncated) return;
 
     const Move = struct { group_id: tabgroup.GroupId, selected: u32 };
-    var moves: [16]Move = undefined;
-    var move_count: usize = 0;
+    var moves: std.ArrayList(Move) = .empty;
+    defer moves.deinit(g_allocator);
+    moves.ensureTotalCapacity(g_allocator, g_tab_groups.groups.count()) catch |err| {
+        log.err("tab refresh skipped: failed to allocate move snapshot: {}", .{err});
+        return;
+    };
 
     var it = g_tab_groups.groups.valueIterator();
     while (it.next()) |group| {
-        if (move_count == moves.len) break;
-
         const leader = g_store.get(group.leader_wid) orelse continue;
         // A parked group is off-screen on purpose and nothing acts on it until
         // its workspace is shown again.
@@ -4670,20 +4760,23 @@ fn refreshTabGroupActiveTabs() void {
         if (on_screen.contains(group.active_wid)) continue;
 
         var app_windows: [128]tabgroup.detect.AppWindow = undefined;
-        const app_count = appWindowSnapshot(group.pid, &on_screen, &app_windows);
+        const app_snapshot = appWindowSnapshot(group.pid, &on_screen, &app_windows);
+        if (app_snapshot.truncated) {
+            log.warn("tab refresh skipped: AX window snapshot truncated pid={d} limit={d}", .{ group.pid, app_windows.len });
+            continue;
+        }
         const selected = tabgroup.detect.selectedTabWindow(
-            app_windows[0..app_count],
+            app_windows[0..app_snapshot.count],
             group.canonical_frame,
         ) orelse continue;
         if (selected == group.active_wid) continue;
 
-        moves[move_count] = .{ .group_id = group.id, .selected = selected };
-        move_count += 1;
+        moves.appendAssumeCapacity(.{ .group_id = group.id, .selected = selected });
     }
 
     // Applied after the walk: adopting a tab writes to the store and to the
     // group's member list.
-    for (moves[0..move_count]) |move| {
+    for (moves.items) |move| {
         const group = g_tab_groups.groups.getPtr(move.group_id) orelse continue;
         const leader = g_store.get(group.leader_wid) orelse continue;
 
@@ -4724,19 +4817,28 @@ fn tryFormTabGroupOnCreate(pid: i32, new_wid: u32) bool {
     });
 
     const on_screen = OnScreenWindows.snapshot();
+    if (on_screen.truncated) return false;
     var candidates: [128]tabgroup.detect.Candidate = undefined;
-    const count = tabCandidates(pid, &on_screen, &candidates);
+    const candidate_snapshot = tabCandidates(pid, &on_screen, &candidates);
+    if (candidate_snapshot.truncated) {
+        log.warn("tab detect skipped: managed candidate snapshot truncated pid={d} limit={d}", .{ pid, candidates.len });
+        return false;
+    }
 
     var app_windows: [128]tabgroup.detect.AppWindow = undefined;
-    const app_count = appWindowSnapshot(pid, &on_screen, &app_windows);
-    const has_tab_group = tabgroup.detect.appHasTabGroup(app_windows[0..app_count]);
+    const app_snapshot = appWindowSnapshot(pid, &on_screen, &app_windows);
+    if (app_snapshot.truncated) {
+        log.warn("tab detect skipped: AX window snapshot truncated pid={d} limit={d}", .{ pid, app_windows.len });
+        return false;
+    }
+    const has_tab_group = tabgroup.detect.appHasTabGroup(app_windows[0..app_snapshot.count]);
 
     // Collected before any removal: removeWindow mutates the workspace window
     // lists that the snapshot describes.
-    var stale_wids: [64]u32 = undefined;
-    const stale_count = tabgroup.detect.staleCandidates(pid, candidates[0..count], &stale_wids);
+    var stale_wids: [128]u32 = undefined;
+    const stale_count = tabgroup.detect.staleCandidates(pid, candidates[0..candidate_snapshot.count], &stale_wids);
 
-    const formed = switch (tabgroup.detect.classifyNewWindow(pid, new_wid, new_frame, candidates[0..count], has_tab_group)) {
+    const formed = switch (tabgroup.detect.classifyNewWindow(pid, new_wid, new_frame, candidates[0..candidate_snapshot.count], has_tab_group)) {
         .standalone => blk: {
             log.debug("tab detect: wid={d} is standalone", .{new_wid});
             break :blk false;
@@ -4917,43 +5019,62 @@ fn removeAppWindows(pid: i32) void {
     untrackPendingRoleWindowsForPid(pid);
     untrackDeferredWindowCandidatesForPid(pid);
     clearDragPreview();
-    var wids: [128]u32 = undefined;
-    var ws_ids: [128]u8 = undefined;
-    var n: usize = 0;
+    var total_removed: usize = 0;
 
-    // Collect managed windows across all workspaces
-    for (&g_workspaces.workspaces) |*ws| {
-        for (ws.windows.items) |wid| {
-            if (g_store.get(wid)) |win| {
-                if (win.pid == pid and n < wids.len) {
-                    wids[n] = wid;
-                    ws_ids[n] = ws.id;
-                    n += 1;
-                }
+    // Iterate in batches because removeWindow mutates the store. Rescan until
+    // no matching entries remain; the old single 128-entry batch silently
+    // leaked every window above the cap after an app termination.
+    while (true) {
+        var wids: [128]u32 = undefined;
+        var count: usize = 0;
+
+        var store_it = g_store.windows.iterator();
+        while (store_it.next()) |entry| {
+            if (entry.value_ptr.pid != pid) continue;
+            if (count == wids.len) break;
+            wids[count] = entry.key_ptr.*;
+            count += 1;
+        }
+
+        if (count == 0) break;
+        for (wids[0..count]) |wid| removeWindow(wid);
+        total_removed += count;
+    }
+
+    if (total_removed > 128) {
+        log.warn("app termination cleanup exceeded one batch pid={d} removed={d}", .{ pid, total_removed });
+    }
+}
+
+fn isAppRunning(pid: i32) ?bool {
+    std.debug.assert(pid > 0);
+    const NSRunningApplication = objc.getClass("NSRunningApplication") orelse return null;
+    const app = NSRunningApplication.msgSend(objc.Object, "runningApplicationWithProcessIdentifier:", .{pid});
+    return app.value != null;
+}
+
+/// Recover app-termination notifications lost to event-ring overflow. Find one
+/// stopped process at a time so store mutation never overlaps map iteration.
+fn removeStoppedAppWindows() bool {
+    var removed_any = false;
+    while (true) {
+        const stopped_pid: ?i32 = blk: {
+            var it = g_store.windows.valueIterator();
+            while (it.next()) |win| {
+                const running = isAppRunning(win.pid) orelse {
+                    log.warn("event overflow: cannot query running applications; skipping termination recovery", .{});
+                    return removed_any;
+                };
+                if (!running) break :blk win.pid;
             }
-        }
-    }
+            break :blk null;
+        };
+        const pid = stopped_pid orelse return removed_any;
 
-    // Also collect suppressed tab members from the store
-    var store_it = g_store.windows.iterator();
-    while (store_it.next()) |entry| {
-        const wid = entry.key_ptr.*;
-        if (entry.value_ptr.pid != pid) continue;
-        if (!g_tab_groups.isSuppressed(wid)) continue;
-        if (n >= wids.len) continue;
-
-        wids[n] = wid;
-        ws_ids[n] = entry.value_ptr.workspace_id;
-        n += 1;
-    }
-
-    for (wids[0..n], ws_ids[0..n]) |wid, ws_id| {
-        _ = g_tab_groups.removeMember(wid);
-        g_store.remove(wid);
-        if (g_workspaces.get(ws_id)) |ws| {
-            ws.removeWindow(wid);
-        }
-        removeFromTiling(ws_id, wid);
+        ax_mod.invalidateApp(pid);
+        ax_observer.unobserveApp(pid);
+        removeAppWindows(pid);
+        removed_any = true;
     }
 }
 
@@ -5098,10 +5219,15 @@ fn appListsWindow(pid: i32, wid: u32) bool {
     std.debug.assert(wid != 0);
 
     var ax_wids: [128]u32 = undefined;
-    const count = bw_get_app_window_ids(pid, &ax_wids);
-    if (count == 0) return true;
+    const snapshot = bw_get_app_window_ids(pid, &ax_wids);
+    if (snapshot.count == 0) return true;
 
-    return std.mem.findScalar(u32, ax_wids[0..count], wid) != null;
+    if (std.mem.findScalar(u32, ax_wids[0..snapshot.count], wid) != null) return true;
+    if (snapshot.truncated) {
+        log.warn("AX window membership inconclusive: snapshot truncated pid={d} wid={d} limit={d}", .{ pid, wid, ax_wids.len });
+        return true;
+    }
+    return false;
 }
 
 /// Adopt a managed window as a member of an on-screen sibling's tab group.
@@ -5121,26 +5247,35 @@ fn adoptWindowAsBackgroundTab(win: window_mod.Window) tabgroup.detect.OffscreenO
     const frame = liveWindowFrame(win.wid);
 
     const on_screen = OnScreenWindows.snapshot();
+    if (on_screen.truncated) return .keep;
     var app_windows: [128]tabgroup.detect.AppWindow = undefined;
-    const app_count = appWindowSnapshot(win.pid, &on_screen, &app_windows);
+    const app_snapshot = appWindowSnapshot(win.pid, &on_screen, &app_windows);
+    if (app_snapshot.truncated) {
+        log.warn("background-tab adoption skipped: AX window snapshot truncated pid={d} limit={d}", .{ win.pid, app_windows.len });
+        return .keep;
+    }
     const listed_in_app = blk: {
-        for (app_windows[0..app_count]) |app_window| {
+        for (app_windows[0..app_snapshot.count]) |app_window| {
             if (app_window.wid == win.wid) break :blk true;
         }
         break :blk false;
     };
 
     var candidates: [128]tabgroup.detect.Candidate = undefined;
-    const count = tabCandidates(win.pid, &on_screen, &candidates);
+    const candidate_snapshot = tabCandidates(win.pid, &on_screen, &candidates);
+    if (candidate_snapshot.truncated) {
+        log.warn("background-tab adoption skipped: candidate snapshot truncated pid={d} limit={d}", .{ win.pid, candidates.len });
+        return .keep;
+    }
 
-    const has_tab_group = tabgroup.detect.appHasTabGroup(app_windows[0..app_count]);
+    const has_tab_group = tabgroup.detect.appHasTabGroup(app_windows[0..app_snapshot.count]);
     const sibling_wid = switch (tabgroup.detect.classifyOffscreenManaged(
         win.wid,
         win.pid,
         frame,
         listed_in_app,
         has_tab_group,
-        candidates[0..count],
+        candidates[0..candidate_snapshot.count],
     )) {
         .keep => {
             log.debug("cleanup: keeping wid={d} pid={d}, the app still lists it", .{ win.wid, win.pid });

--- a/src/objc_classes.zig
+++ b/src/objc_classes.zig
@@ -16,7 +16,14 @@ const std = @import("std");
 const objc = @import("objc");
 const c = objc.c;
 
-const main = @import("main.zig");
+/// Application-owned event sinks invoked by the runtime ObjC classes.
+pub const Callbacks = struct {
+    app_launched: *const fn (i32) void,
+    app_terminated: *const fn (i32) void,
+    active_app_changed: *const fn (i32) void,
+    space_changed: *const fn () void,
+    display_changed: *const fn () void,
+};
 
 /// `NSWorkspaceApplicationKey` is an `NSString * const` exported by AppKit.
 /// Declared `extern var` (not `extern const`) because Zig's `extern const`
@@ -26,7 +33,8 @@ extern var NSWorkspaceApplicationKey: c.id;
 
 /// Allocate and register all bobrwm ObjC classes. Must be called before any
 /// `objc.getClass("BW…")` lookup (i.e. before `initWorkspaceObservers()`).
-pub fn register(allocator: std.mem.Allocator) void {
+pub fn register(allocator: std.mem.Allocator, callbacks: Callbacks) void {
+    g_callbacks = callbacks;
     g_launch_gates = .init(allocator);
     registerObserver();
     registerLaunchGate();
@@ -60,7 +68,7 @@ fn observerAppLaunched(_: c.id, _: c.SEL, note_id: c.id) callconv(.c) void {
     const launched = app.msgSend(bool, "isFinishedLaunching", .{});
     const policy = app.msgSend(i64, "activationPolicy", .{});
     if (launched and policy == 0) {
-        main.bw_workspace_app_launched(pid);
+        g_callbacks.app_launched(pid);
         return;
     }
 
@@ -72,20 +80,20 @@ fn observerAppLaunched(_: c.id, _: c.SEL, note_id: c.id) callconv(.c) void {
 fn observerAppTerminated(_: c.id, _: c.SEL, note_id: c.id) callconv(.c) void {
     const pid = notificationApp(note_id).msgSend(i32, "processIdentifier", .{});
     dropLaunchGate(pid);
-    main.bw_workspace_app_terminated(pid);
+    g_callbacks.app_terminated(pid);
 }
 
 fn observerActiveAppChanged(_: c.id, _: c.SEL, note_id: c.id) callconv(.c) void {
     const pid = notificationApp(note_id).msgSend(i32, "processIdentifier", .{});
-    main.bw_workspace_active_app_changed(pid);
+    g_callbacks.active_app_changed(pid);
 }
 
 fn observerSpaceChanged(_: c.id, _: c.SEL, _: c.id) callconv(.c) void {
-    main.bw_workspace_space_changed();
+    g_callbacks.space_changed();
 }
 
 fn observerDisplayChanged(_: c.id, _: c.SEL, _: c.id) callconv(.c) void {
-    main.bw_workspace_display_changed();
+    g_callbacks.display_changed();
 }
 
 // BWLaunchGate
@@ -100,6 +108,7 @@ const LaunchGate = struct {
 
 /// `pid → LaunchGate`. Holds owning references outside ObjC.
 var g_launch_gates: std.AutoHashMap(i32, LaunchGate) = undefined;
+var g_callbacks: Callbacks = undefined;
 
 fn registerLaunchGate() void {
     const NSObject = objc.getClass("NSObject").?;
@@ -148,7 +157,7 @@ fn launchGateObserveValue(
     if (!finished or policy != 0) return;
 
     const pid = app.msgSend(i32, "processIdentifier", .{});
-    main.bw_workspace_app_launched(pid);
+    g_callbacks.app_launched(pid);
     dropLaunchGate(pid);
 }
 

--- a/src/runtime_paths.zig
+++ b/src/runtime_paths.zig
@@ -1,27 +1,24 @@
-//! User-private runtime paths shared by the daemon and companion clients.
+//! Runtime paths shared by the daemon and companion clients.
 
 const std = @import("std");
 
 const runtime_dir_suffix = "Library/Caches/bobrwm";
-const socket_name = "bobrwm.sock";
 const log_name = "bobrwm.log";
 
 pub fn socketPathAlloc(allocator: std.mem.Allocator) ![:0]u8 {
-    const home = getenv("HOME") orelse return error.MissingHome;
     return std.fmt.allocPrintSentinel(
         allocator,
-        "{s}/{s}/{s}",
-        .{ home, runtime_dir_suffix, socket_name },
+        "/tmp/bobrwm_{d}.sock",
+        .{std.c.getuid()},
         0,
     );
 }
 
 pub fn socketPathBuf(buf: []u8) ![:0]u8 {
-    const home = getenv("HOME") orelse return error.MissingHome;
     return std.fmt.bufPrintSentinel(
         buf,
-        "{s}/{s}/{s}",
-        .{ home, runtime_dir_suffix, socket_name },
+        "/tmp/bobrwm_{d}.sock",
+        .{std.c.getuid()},
         0,
     );
 }
@@ -36,9 +33,7 @@ pub fn logPathBuf(buf: []u8) ![:0]u8 {
     );
 }
 
-/// Create and lock down the directory that contains runtime files.
-/// Keeping it below the user's home directory prevents other local users from
-/// pre-creating predictable socket or log paths in a world-writable directory.
+/// Create and lock down the directory that contains the daemon log.
 pub fn ensureRuntimeDir(allocator: std.mem.Allocator) !void {
     const home = getenv("HOME") orelse return error.MissingHome;
     const path = try std.fmt.allocPrintSentinel(

--- a/src/runtime_paths.zig
+++ b/src/runtime_paths.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 
 const runtime_dir_suffix = "Library/Caches/bobrwm";
 const socket_name = "bobrwm.sock";
+const log_name = "bobrwm.log";
 
 pub fn socketPathAlloc(allocator: std.mem.Allocator) ![:0]u8 {
     const home = getenv("HOME") orelse return error.MissingHome;
@@ -25,9 +26,19 @@ pub fn socketPathBuf(buf: []u8) ![:0]u8 {
     );
 }
 
-/// Create and lock down the directory that contains the daemon socket.
+pub fn logPathBuf(buf: []u8) ![:0]u8 {
+    const home = getenv("HOME") orelse return error.MissingHome;
+    return std.fmt.bufPrintSentinel(
+        buf,
+        "{s}/{s}/{s}",
+        .{ home, runtime_dir_suffix, log_name },
+        0,
+    );
+}
+
+/// Create and lock down the directory that contains runtime files.
 /// Keeping it below the user's home directory prevents other local users from
-/// pre-creating the predictable socket path in a world-writable directory.
+/// pre-creating predictable socket or log paths in a world-writable directory.
 pub fn ensureRuntimeDir(allocator: std.mem.Allocator) !void {
     const home = getenv("HOME") orelse return error.MissingHome;
     const path = try std.fmt.allocPrintSentinel(

--- a/src/runtime_paths.zig
+++ b/src/runtime_paths.zig
@@ -1,0 +1,61 @@
+//! User-private runtime paths shared by the daemon and companion clients.
+
+const std = @import("std");
+
+const runtime_dir_suffix = "Library/Caches/bobrwm";
+const socket_name = "bobrwm.sock";
+
+pub fn socketPathAlloc(allocator: std.mem.Allocator) ![:0]u8 {
+    const home = getenv("HOME") orelse return error.MissingHome;
+    return std.fmt.allocPrintSentinel(
+        allocator,
+        "{s}/{s}/{s}",
+        .{ home, runtime_dir_suffix, socket_name },
+        0,
+    );
+}
+
+pub fn socketPathBuf(buf: []u8) ![:0]u8 {
+    const home = getenv("HOME") orelse return error.MissingHome;
+    return std.fmt.bufPrintSentinel(
+        buf,
+        "{s}/{s}/{s}",
+        .{ home, runtime_dir_suffix, socket_name },
+        0,
+    );
+}
+
+/// Create and lock down the directory that contains the daemon socket.
+/// Keeping it below the user's home directory prevents other local users from
+/// pre-creating the predictable socket path in a world-writable directory.
+pub fn ensureRuntimeDir(allocator: std.mem.Allocator) !void {
+    const home = getenv("HOME") orelse return error.MissingHome;
+    const path = try std.fmt.allocPrintSentinel(
+        allocator,
+        "{s}/{s}",
+        .{ home, runtime_dir_suffix },
+        0,
+    );
+    defer allocator.free(path);
+
+    if (std.c.mkdir(path, 0o700) != 0 and std.c.access(path, 0) != 0) {
+        return error.CreateRuntimeDirFailed;
+    }
+
+    const flags: std.c.O = .{
+        .ACCMODE = .RDONLY,
+        .DIRECTORY = true,
+        .NOFOLLOW = true,
+        .CLOEXEC = true,
+    };
+    const fd = std.c.open(path, flags);
+    if (fd < 0) return error.InvalidRuntimeDir;
+    defer _ = std.c.close(fd);
+
+    if (std.c.fchmod(fd, 0o700) != 0) return error.SecureRuntimeDirFailed;
+}
+
+fn getenv(name: [*:0]const u8) ?[]const u8 {
+    const raw = std.c.getenv(name) orelse return null;
+    return std.mem.span(raw);
+}

--- a/src/shim_api.zig
+++ b/src/shim_api.zig
@@ -17,6 +17,7 @@ pub const BW_EVENT_DISPLAY_CHANGED: u8 = @intFromEnum(event_mod.EventKind.displa
 pub const BW_EVENT_FOCUSED_WINDOW_CHANGED: u8 = @intFromEnum(event_mod.EventKind.focused_window_changed);
 pub const BW_EVENT_MOUSE_DOWN: u8 = @intFromEnum(event_mod.EventKind.mouse_down);
 pub const BW_EVENT_MOUSE_UP: u8 = @intFromEnum(event_mod.EventKind.mouse_up);
+pub const BW_EVENT_MOUSE_DRAGGED: u8 = @intFromEnum(event_mod.EventKind.mouse_dragged);
 pub const BW_EVENT_ROLE_POLL_TICK: u8 = @intFromEnum(event_mod.EventKind.role_poll_tick);
 
 pub const BW_HK_FOCUS_WORKSPACE: u8 = @intFromEnum(event_mod.EventKind.hk_focus_workspace);

--- a/src/signal_transport.zig
+++ b/src/signal_transport.zig
@@ -1,0 +1,116 @@
+//! Async-signal-safe bridge from POSIX termination signals to the main queue.
+//!
+//! The process signal handler only writes one byte to a nonblocking pipe. A
+//! dispatch read source drains it and invokes application shutdown on the main
+//! queue, where AppKit and window restoration are safe.
+
+const std = @import("std");
+const posix = std.posix;
+const c = @import("c");
+const cg_extra = @import("cg_extra");
+
+const StopFn = *const fn () void;
+
+var g_source: c.dispatch_source_t = null;
+var g_read_fd: c_int = -1;
+var g_write_fd: c_int = -1;
+var g_stop: ?StopFn = null;
+
+const graceful_signals = [_]posix.SIG{
+    posix.SIG.INT, posix.SIG.TERM,
+    posix.SIG.HUP, posix.SIG.QUIT,
+};
+
+/// Create the self-pipe, attach its main-queue reader, and install handlers.
+pub fn init(stop: StopFn) !void {
+    std.debug.assert(g_source == null);
+    std.debug.assert(g_read_fd < 0 and g_write_fd < 0);
+    std.debug.assert(g_stop == null);
+
+    var fds: [2]c_int = undefined;
+    if (c.pipe(&fds) != 0) return error.SignalPipeCreateFailed;
+    errdefer {
+        _ = std.c.close(fds[0]);
+        _ = std.c.close(fds[1]);
+    }
+    try configurePipeFd(fds[0]);
+    try configurePipeFd(fds[1]);
+
+    const source = c.dispatch_source_create(
+        cg_extra.DISPATCH_SOURCE_TYPE_READ(),
+        @intCast(fds[0]),
+        0,
+        cg_extra.dispatch_get_main_queue(),
+    ) orelse return error.SignalSourceCreateFailed;
+
+    g_read_fd = fds[0];
+    g_write_fd = fds[1];
+    g_stop = stop;
+    g_source = source;
+    c.dispatch_source_set_event_handler_f(source, sourceReady);
+    c.dispatch_resume(.{ ._ds = source });
+    installHandlers();
+}
+
+/// Restore default handlers, release the dispatch source, and close the pipe.
+pub fn deinit() void {
+    uninstallHandlers();
+
+    if (g_source) |source| {
+        c.dispatch_source_cancel(source);
+        c.dispatch_release(.{ ._ds = source });
+        g_source = null;
+    }
+    if (g_read_fd >= 0) {
+        const fd = g_read_fd;
+        g_read_fd = -1;
+        _ = std.c.close(fd);
+    }
+    if (g_write_fd >= 0) {
+        const fd = g_write_fd;
+        g_write_fd = -1;
+        _ = std.c.close(fd);
+    }
+    g_stop = null;
+}
+
+fn configurePipeFd(fd: c_int) !void {
+    if (c.fcntl(fd, c.F_SETFL, c.O_NONBLOCK) < 0) return error.SignalPipeConfigureFailed;
+    if (c.fcntl(fd, c.F_SETFD, c.FD_CLOEXEC) < 0) return error.SignalPipeConfigureFailed;
+}
+
+fn gracefulSignalHandler(sig: posix.SIG) callconv(.c) void {
+    const byte: u8 = @intCast(@intFromEnum(sig));
+    _ = c.write(g_write_fd, &byte, 1);
+}
+
+fn sourceReady(context: ?*anyopaque) callconv(.c) void {
+    _ = context;
+    if (g_read_fd < 0) return;
+
+    var buf: [64]u8 = undefined;
+    while (c.read(g_read_fd, &buf, buf.len) > 0) {}
+    g_stop.?();
+}
+
+fn installHandlers() void {
+    for (graceful_signals) |sig| {
+        var action: posix.Sigaction = .{
+            .handler = .{ .handler = gracefulSignalHandler },
+            .mask = posix.sigemptyset(),
+            .flags = posix.SA.RESTART,
+        };
+        posix.sigaction(sig, &action, null);
+    }
+}
+
+fn uninstallHandlers() void {
+    for (graceful_signals) |sig| {
+        var action: posix.Sigaction = .{
+            .handler = .{ .handler = posix.SIG.DFL },
+            .mask = posix.sigemptyset(),
+            .flags = 0,
+        };
+        posix.sigaction(sig, &action, null);
+    }
+}

--- a/src/spsc_queue.zig
+++ b/src/spsc_queue.zig
@@ -1,0 +1,68 @@
+//! Fixed-capacity single-producer, single-consumer queue.
+//!
+//! A producer may itself be protected by an external lock, which is how the
+//! AX event bridge serializes multiple callback threads before entering this
+//! queue. The consumer must remain unique.
+
+const std = @import("std");
+
+/// Build a queue that holds exactly `capacity` values without allocation.
+pub fn Queue(comptime T: type, comptime capacity: usize) type {
+    if (capacity == 0) @compileError("queue capacity must be positive");
+
+    return struct {
+        const Self = @This();
+        const storage_len = capacity + 1;
+
+        buf: [storage_len]T = undefined,
+        head: std.atomic.Value(usize) = .init(0),
+        tail: std.atomic.Value(usize) = .init(0),
+
+        /// Publish a value, returning false without modifying the queue when
+        /// all advertised slots are occupied.
+        pub fn push(self: *Self, value: T) bool {
+            const tail = self.tail.load(.monotonic);
+            const next = (tail + 1) % storage_len;
+            if (next == self.head.load(.acquire)) return false;
+
+            self.buf[tail] = value;
+            self.tail.store(next, .release);
+            return true;
+        }
+
+        /// Remove the oldest published value, or null when the queue is empty.
+        pub fn pop(self: *Self) ?T {
+            const head = self.head.load(.monotonic);
+            if (head == self.tail.load(.acquire)) return null;
+
+            const value = self.buf[head];
+            self.head.store((head + 1) % storage_len, .release);
+            return value;
+        }
+    };
+}
+
+test "queue exposes its full capacity and preserves FIFO order" {
+    var queue: Queue(u8, 3) = .{};
+
+    try std.testing.expect(queue.push(1));
+    try std.testing.expect(queue.push(2));
+    try std.testing.expect(queue.push(3));
+    try std.testing.expect(!queue.push(4));
+
+    try std.testing.expectEqual(@as(?u8, 1), queue.pop());
+    try std.testing.expectEqual(@as(?u8, 2), queue.pop());
+    try std.testing.expectEqual(@as(?u8, 3), queue.pop());
+    try std.testing.expectEqual(@as(?u8, null), queue.pop());
+}
+
+test "queue wraps without reordering values" {
+    var queue: Queue(u16, 2) = .{};
+
+    try std.testing.expect(queue.push(10));
+    try std.testing.expect(queue.push(20));
+    try std.testing.expectEqual(@as(?u16, 10), queue.pop());
+    try std.testing.expect(queue.push(30));
+    try std.testing.expectEqual(@as(?u16, 20), queue.pop());
+    try std.testing.expectEqual(@as(?u16, 30), queue.pop());
+}

--- a/src/statusbar.zig
+++ b/src/statusbar.zig
@@ -7,15 +7,14 @@
 //! changing one means changing both.
 
 const std = @import("std");
-const objc = @import("objc");
 
 const config_mod = @import("config.zig");
-const main = @import("main.zig");
 const workspace_mod = @import("workspace.zig");
 
 const log = std.log.scoped(.statusbar);
 
-const MenuBarCallbacks = extern struct {
+/// Application-owned actions invoked by the Swift menu bar on the main thread.
+pub const Callbacks = extern struct {
     retile: *const fn () callconv(.c) void,
     open_config: *const fn () callconv(.c) void,
     previous_workspace: *const fn () callconv(.c) void,
@@ -42,7 +41,7 @@ const ActionShortcuts = extern struct {
     next_workspace: ?[*:0]const u8,
 };
 
-extern fn bw_menubar_init(callbacks: MenuBarCallbacks) void;
+extern fn bw_menubar_init(callbacks: Callbacks) void;
 extern fn bw_menubar_deinit() void;
 extern fn bw_menubar_set_workspaces(
     workspaces: ?[*]const Workspace,
@@ -66,21 +65,16 @@ var g_nav_shortcut_storage: [2][max_shortcut_bytes]u8 = undefined;
 
 var g_initialized = false;
 
+/// Create the Swift menu bar and publish the initial workspace identity rows.
 pub fn init(
     workspaces: []const workspace_mod.Workspace,
     config: *const config_mod.Config,
+    callbacks: Callbacks,
 ) void {
     std.debug.assert(!g_initialized);
     std.debug.assert(workspaces.len > 0 and workspaces.len <= workspace_mod.max_workspaces);
 
-    bw_menubar_init(.{
-        .retile = onRetile,
-        .open_config = onOpenConfig,
-        .previous_workspace = onPreviousWorkspace,
-        .next_workspace = onNextWorkspace,
-        .switch_to_workspace = onSwitchToWorkspace,
-        .quit = onQuit,
-    });
+    bw_menubar_init(callbacks);
     g_initialized = true;
 
     updateWorkspaceMenu(workspaces, config);
@@ -194,38 +188,4 @@ test "workspace ABI name truncation preserves valid UTF-8" {
     try std.testing.expect(std.unicode.utf8ValidateSlice(encoded));
     try std.testing.expectEqual(@as(usize, 62), encoded.len);
     try std.testing.expectEqualSlices(u8, name[0..62], encoded);
-}
-
-// Menu callbacks. These run on the main thread while the menu dismisses, so
-// they can mutate Bobrwm state directly.
-
-fn onRetile() callconv(.c) void {
-    main.bw_retile();
-}
-
-fn onOpenConfig() callconv(.c) void {
-    main.bw_status_bar_action(.open_config);
-}
-
-fn onPreviousWorkspace() callconv(.c) void {
-    main.bw_status_bar_action(.previous_workspace);
-}
-
-fn onNextWorkspace() callconv(.c) void {
-    main.bw_status_bar_action(.next_workspace);
-}
-
-fn onSwitchToWorkspace(workspace_id: u8) callconv(.c) void {
-    if (workspace_id == 0 or workspace_id > workspace_mod.max_workspaces) return;
-    main.bw_status_bar_action(.{ .workspace = workspace_id });
-}
-
-/// Shutdown stays on the Zig side so window restoration keeps running before
-/// AppKit tears the process down; the UI library is presentation only.
-fn onQuit() callconv(.c) void {
-    main.bw_will_quit();
-
-    const NSApplication = objc.getClass("NSApplication").?;
-    const app = NSApplication.msgSend(objc.Object, "sharedApplication", .{});
-    app.msgSend(void, "terminate:", .{@as(objc.Object, .{ .value = null })});
 }

--- a/src/tabgroup.zig
+++ b/src/tabgroup.zig
@@ -69,42 +69,77 @@ pub const TabGroupManager = struct {
 
     /// Create a new group. First member becomes leader + active.
     pub fn createGroup(self: *TabGroupManager, pid: i32, wid: WindowId, frame: Frame) !GroupId {
+        return self.createGroupFromMembers(pid, &.{wid}, frame);
+    }
+
+    /// Create a new group with a leader and one additional member.
+    pub fn createGroupWithMember(
+        self: *TabGroupManager,
+        pid: i32,
+        leader_wid: WindowId,
+        member_wid: WindowId,
+        frame: Frame,
+    ) !GroupId {
+        if (leader_wid == member_wid) return error.DuplicateWindow;
+        return self.createGroupFromMembers(pid, &.{ leader_wid, member_wid }, frame);
+    }
+
+    fn createGroupFromMembers(
+        self: *TabGroupManager,
+        pid: i32,
+        initial_members: []const WindowId,
+        frame: Frame,
+    ) !GroupId {
+        std.debug.assert(pid > 0);
+        std.debug.assert(initial_members.len > 0);
+
+        for (initial_members) |wid| {
+            if (wid == 0) return error.InvalidWindow;
+            if (self.wid_to_group.contains(wid)) return error.WindowAlreadyGrouped;
+        }
+
         const id = self.next_id;
-        self.next_id += 1;
+        if (id == std.math.maxInt(GroupId)) return error.GroupIdExhausted;
 
         var members: std.ArrayListUnmanaged(WindowId) = .empty;
-        try members.ensureTotalCapacity(self.allocator, 4);
-        try members.append(self.allocator, wid);
+        errdefer members.deinit(self.allocator);
+        try members.ensureTotalCapacity(self.allocator, @max(4, initial_members.len));
+        try self.groups.ensureUnusedCapacity(self.allocator, 1);
+        try self.wid_to_group.ensureUnusedCapacity(self.allocator, @intCast(initial_members.len));
 
-        try self.groups.put(self.allocator, id, .{
+        for (initial_members) |wid| members.appendAssumeCapacity(wid);
+        self.groups.putAssumeCapacityNoClobber(id, .{
             .id = id,
             .pid = pid,
-            .leader_wid = wid,
-            .active_wid = wid,
+            .leader_wid = initial_members[0],
+            .active_wid = initial_members[initial_members.len - 1],
             .members = members,
             .canonical_frame = frame,
         });
-        try self.wid_to_group.put(self.allocator, wid, id);
+        for (initial_members) |wid| self.wid_to_group.putAssumeCapacityNoClobber(wid, id);
+        self.next_id += 1;
 
-        log.info("created group {d} leader={d} pid={d}", .{ id, wid, pid });
+        log.info("created group {d} leader={d} pid={d}", .{ id, initial_members[0], pid });
         return id;
     }
 
     /// Add a window to an existing group.
     pub fn addMember(self: *TabGroupManager, group_id: GroupId, wid: WindowId) !void {
-        const g = self.groups.getPtr(group_id) orelse return;
+        if (wid == 0) return error.InvalidWindow;
+        if (self.wid_to_group.get(wid)) |existing_group_id| {
+            if (existing_group_id == group_id) return;
+            return error.WindowAlreadyGrouped;
+        }
+
+        const g = self.groups.getPtr(group_id) orelse return error.GroupNotFound;
         for (g.members.items) |m| {
             if (m == wid) return;
         }
 
-        if (g.members.items.len == g.members.capacity) {
-            const current_capacity = g.members.capacity;
-            const next_capacity: usize = if (current_capacity < 4) 4 else current_capacity * 2;
-            try g.members.ensureTotalCapacity(self.allocator, next_capacity);
-        }
-
-        try g.members.append(self.allocator, wid);
-        try self.wid_to_group.put(self.allocator, wid, group_id);
+        try g.members.ensureUnusedCapacity(self.allocator, 1);
+        try self.wid_to_group.ensureUnusedCapacity(self.allocator, 1);
+        g.members.appendAssumeCapacity(wid);
+        self.wid_to_group.putAssumeCapacityNoClobber(wid, group_id);
 
         log.debug("added wid={d} to group {d} (now {d} members)", .{
             wid, group_id, g.members.items.len,
@@ -235,6 +270,46 @@ pub const TabGroupManager = struct {
 const testing = std.testing;
 
 const test_frame: Frame = .{ .x = 0, .y = 0, .width = 800, .height = 600 };
+
+fn exerciseAllocationFailures(allocator: std.mem.Allocator) !void {
+    var mgr = TabGroupManager.init(allocator);
+    defer mgr.deinit();
+
+    const gid = mgr.createGroupWithMember(100, 1, 2, test_frame) catch |err| {
+        try testing.expectEqual(@as(u32, 0), mgr.groups.count());
+        try testing.expectEqual(@as(u32, 0), mgr.wid_to_group.count());
+        try testing.expectEqual(@as(GroupId, 1), mgr.next_id);
+        return err;
+    };
+
+    mgr.addMember(gid, 3) catch |err| {
+        const group = mgr.groupOf(1) orelse return error.TestUnexpectedResult;
+        try testing.expectEqualSlices(WindowId, &.{ 1, 2 }, group.members.items);
+        try testing.expect(mgr.groupOf(3) == null);
+        try testing.expectEqual(@as(u32, 2), mgr.wid_to_group.count());
+        return err;
+    };
+
+    const group = mgr.groupOf(1) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualSlices(WindowId, &.{ 1, 2, 3 }, group.members.items);
+    try testing.expectEqual(gid, mgr.wid_to_group.get(3).?);
+}
+
+test "group mutations remain consistent across allocation failures" {
+    try testing.checkAllAllocationFailures(testing.allocator, exerciseAllocationFailures, .{});
+}
+
+test "a window cannot belong to two groups" {
+    var mgr = TabGroupManager.init(testing.allocator);
+    defer mgr.deinit();
+
+    const first = try mgr.createGroup(100, 1, test_frame);
+    const second = try mgr.createGroup(200, 2, test_frame);
+
+    try testing.expectError(error.WindowAlreadyGrouped, mgr.addMember(second, 1));
+    try testing.expectEqual(first, mgr.wid_to_group.get(1).?);
+    try testing.expectEqualSlices(WindowId, &.{2}, mgr.groups.getPtr(second).?.members.items);
+}
 
 test "removeMember hands leadership to a surviving member" {
     var mgr = TabGroupManager.init(testing.allocator);

--- a/src/tabgroup.zig
+++ b/src/tabgroup.zig
@@ -329,6 +329,21 @@ test "removeMember hands leadership to a surviving member" {
     }
 }
 
+test "focused member becomes active without taking the leader slot" {
+    var mgr = TabGroupManager.init(testing.allocator);
+    defer mgr.deinit();
+
+    _ = try mgr.createGroupWithMember(100, 1, 2, test_frame);
+    try testing.expectEqual(@as(WindowId, 2), mgr.resolveActive(1));
+
+    mgr.setActive(1);
+    try testing.expectEqual(@as(WindowId, 1), mgr.resolveActive(1));
+
+    mgr.setActive(2);
+    try testing.expectEqual(@as(WindowId, 1), mgr.resolveLeader(2));
+    try testing.expectEqual(@as(WindowId, 2), mgr.resolveActive(1));
+}
+
 test "removeMember dissolves a two-member group to a solo survivor" {
     var mgr = TabGroupManager.init(testing.allocator);
     defer mgr.deinit();

--- a/src/window.zig
+++ b/src/window.zig
@@ -74,6 +74,21 @@ pub const WindowStore = struct {
         try self.windows.put(window.wid, window);
     }
 
+    /// Reserve entries before a mutation that must commit across multiple
+    /// containers. Capacity changes are harmless if a later reservation fails.
+    pub fn ensureUnusedCapacity(self: *WindowStore, additional_count: u32) !void {
+        try self.windows.ensureUnusedCapacity(additional_count);
+    }
+
+    /// Insert after a matching `ensureUnusedCapacity` call.
+    pub fn putAssumeCapacity(self: *WindowStore, window: Window) void {
+        std.debug.assert(window.wid > 0);
+        std.debug.assert(window.pid > 0);
+        std.debug.assert(window.workspace_id > 0);
+        std.debug.assert(window.display_id > 0);
+        self.windows.putAssumeCapacity(window.wid, window);
+    }
+
     pub fn get(self: *const WindowStore, wid: WindowId) ?Window {
         return self.windows.get(wid);
     }

--- a/src/window.zig
+++ b/src/window.zig
@@ -11,6 +11,9 @@ pub const Window = struct {
     wid: WindowId,
     pid: i32,
     title: ?[]const u8,
+    /// Last geometry bobrwm deliberately accepted: either a successful AX
+    /// target or a user/external frame admitted by the ownership coordinator.
+    /// This is not an unconditionally live WindowServer observation.
     frame: Frame,
     is_minimized: bool,
     is_fullscreen: bool = false,

--- a/src/workspace.zig
+++ b/src/workspace.zig
@@ -71,6 +71,21 @@ pub const Workspace = struct {
         try self.windows.append(self.allocator, wid);
     }
 
+    /// Reserve entries before a mutation that must commit across multiple
+    /// containers. Capacity changes are harmless if a later reservation fails.
+    pub fn ensureUnusedWindowCapacity(self: *Workspace, additional_count: usize) !void {
+        try self.windows.ensureUnusedCapacity(self.allocator, additional_count);
+    }
+
+    /// Append after a matching `ensureUnusedWindowCapacity` call.
+    pub fn addWindowAssumeCapacity(self: *Workspace, wid: Window.WindowId) void {
+        std.debug.assert(wid != 0);
+        for (self.windows.items) |existing| {
+            std.debug.assert(existing != wid);
+        }
+        self.windows.appendAssumeCapacity(wid);
+    }
+
     /// Replace a window ID in-place, preserving its position in the window
     /// list. Used for tab-group leader succession. Returns true when old_wid
     /// was present and replaced.

--- a/src/workspace.zig
+++ b/src/workspace.zig
@@ -23,6 +23,18 @@ pub fn followFocusAction(workspace_visible: bool, transition_active: bool) Follo
     return .switch_workspace;
 }
 
+/// Whether `actual` physically covers the complete region assigned by
+/// `target`. Apps may clamp a tile larger than requested, which is safe for a
+/// reveal; exact frame equality would unnecessarily hold the outgoing
+/// workspace in front of an already covered display.
+pub fn frameCoversTarget(actual: Window.Window.Frame, target: Window.Window.Frame) bool {
+    const tolerance = Window.Window.Frame.tolerance;
+    return actual.x <= target.x + tolerance and
+        actual.y <= target.y + tolerance and
+        actual.x + actual.width >= target.x + target.width - tolerance and
+        actual.y + actual.height >= target.y + target.height - tolerance;
+}
+
 /// Bounded so focus bookkeeping never allocates. Entries beyond the cap are
 /// the least recently focused windows; losing them only degrades the
 /// focus-after-close fallback to the first-window heuristic.
@@ -350,4 +362,15 @@ test "follow focus defers hidden windows through the transition settle tail" {
     try t.expectEqual(FollowFocusAction.ignore, followFocusAction(true, true));
     try t.expectEqual(FollowFocusAction.defer_until_settled, followFocusAction(false, true));
     try t.expectEqual(FollowFocusAction.switch_workspace, followFocusAction(false, false));
+}
+
+test "physical reveal accepts exact and clamped-larger frames only" {
+    const t = std.testing;
+    const target: Window.Window.Frame = .{ .x = 4, .y = 37, .width = 750, .height = 941 };
+
+    try t.expect(frameCoversTarget(target, target));
+    try t.expect(frameCoversTarget(.{ .x = 0, .y = 33, .width = 800, .height = 949 }, target));
+    try t.expect(!frameCoversTarget(.{ .x = 100, .y = 37, .width = 750, .height = 941 }, target));
+    try t.expect(!frameCoversTarget(.{ .x = 4, .y = 37, .width = 600, .height = 941 }, target));
+    try t.expect(!frameCoversTarget(.{ .x = 1507, .y = 977, .width = 750, .height = 941 }, target));
 }


### PR DESCRIPTION
This is the culmination of Codex and I running through a huge pair session to try and fix some of the major problems in BobrWM. Patterns across the board include much better handling and recovery from error states/illegal windowing states but here:

- Adds a geometry ownership coordinator to reconcile AX intents with WindowServer state.
- Finds the active tab before running actions so things like full screen aren't gonna break when an application has the NSWindow AXDocument bug we know about
- Stops the wallpaper from flashing on workspace switch by forcing a retile before switch.
- Brings atomicity to window state actions so things are basically "transactions".
- Moved IPC reads off the main thread.
- Synchronizes AX observer teardown to eliminate callback lifetime races.
- Defers signal-driven shutdown work into the main queue.
- Hardens config validation.
- Makes Zig the callback owner for the SwiftUI application instead of the other way.
- Fixes reversed swipe gesture direction.
- Add real CI and pin Zig.