### PR TITLE
dev/uzaaft - lg and reconnect improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,13 @@ Each bobrwm workspace is assigned to exactly one ordinary Mission Control
 Space across all displays. At startup, the primary display receives the lowest
 workspace numbers in native ordinal order, so Bobrwm workspace 1 maps to its
 native Space 1. Secondary displays follow in stable display order, with at
-least one workspace reserved for each. Assignments are then preserved by native
-Space ID across topology observations. Configure at least as many ordinary
-Mission Control Spaces in total as Bobrwm workspaces, with at least one on every
-managed display. Bobrwm creates missing Spaces on the primary display and
+least one workspace reserved for each. Display configuration changes, including
+disconnecting or reconnecting a monitor, rebuild this numbering in native Space
+order. Renumbering keeps windows, layouts and focus history attached to surviving
+Spaces. Ordinary Space observations preserve assignments by native Space ID.
+Configure at least as many ordinary Mission Control Spaces in total as Bobrwm
+workspaces, with at least one on every managed display. Bobrwm creates missing
+Spaces on the primary display and
 removes trailing extras so the physical count matches the configured workspace
 count. It watches the native topology while running and reapplies this invariant
 after external Space creation or deletion.

--- a/src/main.zig
+++ b/src/main.zig
@@ -2180,7 +2180,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
     const primary_id = primaryDisplayId();
     // Capture WindowServer topology before discovering windows so native Space
     // membership and the deterministic logical mapping agree from startup.
-    const topology = captureNativeTopology() orelse {
+    const topology = captureNativeTopology(.native_order) orelse {
         log.err("could not map configured workspaces to Mission Control Spaces", .{});
         return error.NativeSpaceMappingUnavailable;
     };
@@ -3287,8 +3287,8 @@ fn completeNativeWorkspaceMove(pending: state_mod.PendingNativeWorkspaceMove) vo
 
 /// Full reconcile after a topology change: rebuild display/workspace state,
 /// pick up windows, retile, refresh the bar.
-fn reconcileDisplays() void {
-    if (!reconcileDisplayChange()) return;
+fn reconcileDisplays(mapping: state_mod.NativeTopologyMapping) void {
+    if (!reconcileDisplayChange(mapping)) return;
     reconcileNativeWindowAssignmentsFromWindowServer(false);
     discoverWindows();
     retile();
@@ -3429,18 +3429,18 @@ fn reconcileNativeSpaceTopologyIfNeeded() void {
             log.warn("live native Space capacity reconciliation failed", .{});
             return;
         }
-        reconcileDisplays();
+        reconcileDisplays(.preserve_space_ids);
         return;
     }
 
-    const topology = nativeTopologyFromSnapshot(&snapshot) orelse return;
+    const topology = nativeTopologyFromSnapshot(&snapshot, .preserve_space_ids) orelse return;
     if (g_state.native_topology.eql(&topology)) return;
 
     log.debug("native Space topology changed", .{});
-    reconcileDisplays();
+    reconcileDisplays(.preserve_space_ids);
 }
 
-fn captureNativeTopology() ?state_mod.NativeTopology {
+fn captureNativeTopology(mapping: state_mod.NativeTopologyMapping) ?state_mod.NativeTopology {
     const sky = &g_sky.?;
     var snapshot = sky.nativeSpaceTopology() orelse {
         log.warn("native topology: WindowServer snapshot unavailable", .{});
@@ -3448,10 +3448,10 @@ fn captureNativeTopology() ?state_mod.NativeTopology {
     };
     defer snapshot.deinit();
 
-    return nativeTopologyFromSnapshot(&snapshot);
+    return nativeTopologyFromSnapshot(&snapshot, mapping);
 }
 
-fn nativeTopologyFromSnapshot(snapshot: *const skylight.NativeSpaceTopology) ?state_mod.NativeTopology {
+fn nativeTopologyFromSnapshot(snapshot: *const skylight.NativeSpaceTopology, mapping: state_mod.NativeTopologyMapping) ?state_mod.NativeTopology {
     var observation: state_mod.NativeTopologyObservation = .{};
     var captured_space_count: u16 = 0;
     const display_indices = stableDisplayIndices();
@@ -3505,6 +3505,7 @@ fn nativeTopologyFromSnapshot(snapshot: *const skylight.NativeSpaceTopology) ?st
         &g_state.spaces,
         workspaceCount(),
         primaryDisplayId(),
+        mapping,
     );
 }
 
@@ -3637,11 +3638,11 @@ fn executeStateEffect(effect: state_mod.Effect) void {
         .focus_retry_expired => |process_id| log.debug("focus-retry: gave up pid={d}", .{process_id}),
         .display_resettle_due => {
             log.debug("display resettle", .{});
-            reconcileDisplays();
+            reconcileDisplays(g_state.display_resettle_mapping);
         },
         .reconcile_displays => {
             log.debug("display changed", .{});
-            reconcileDisplays();
+            reconcileDisplays(.native_order);
         },
         .focus_window => |focus| {
             _ = bw_ax_focus_window(focus.process_id, focus.window_id);
@@ -4115,7 +4116,7 @@ fn executeWorkspaceSwitch(workspace_switch: state_mod.WorkspaceSwitchEffect) voi
 
 fn observeNativeTopology(epoch: state_mod.Epoch) void {
     const at_ms = nativeStateNowMs();
-    const topology = captureNativeTopology() orelse {
+    const topology = captureNativeTopology(.preserve_space_ids) orelse {
         dispatchStateEvent(.{ .native_topology_unavailable = .{
             .epoch = epoch,
             .at_ms = at_ms,
@@ -5385,9 +5386,10 @@ fn handleExternalWindowGeometry(wid: u32, frame: window_mod.Window.Frame) void {
 
 /// Reconciles workspace/display state after monitor topology changes.
 ///
-/// Native Space IDs preserve surviving assignments. New physical Spaces take
-/// the remaining logical workspace IDs during topology mapping.
-fn reconcileDisplayChange() bool {
+/// Display events rebuild native ordinal numbering on both the leading and
+/// trailing observations because macOS can restore Space order after its
+/// first display notification. Routine topology repair preserves Space IDs.
+fn reconcileDisplayChange(mapping: state_mod.NativeTopologyMapping) bool {
     const focused_uuid: ?[16]u8 = blk: {
         const slot = displayIndexById(focusedDisplayId()) orelse break :blk null;
         break :blk g_displays[slot].uuid;
@@ -5398,10 +5400,13 @@ fn reconcileDisplayChange() bool {
     refreshDisplays();
 
     const restored_focused_display_id = displayIdForUuid(focused_uuid) orelse primaryDisplayId();
-    const native_topology = (if (reconcileNativeSpaceCapacity()) captureNativeTopology() else null) orelse {
+    const native_topology = (if (reconcileNativeSpaceCapacity()) captureNativeTopology(mapping) else null) orelse {
         g_displays = previous_displays;
         g_display_count = previous_display_count;
-        dispatchStateEvent(.{ .display_reconcile_unavailable = nativeStateNowMs() });
+        dispatchStateEvent(.{ .display_reconcile_unavailable = .{
+            .at_ms = nativeStateNowMs(),
+            .mapping = mapping,
+        } });
         log.debug("display reconcile deferred until native Space topology is available", .{});
         return false;
     };

--- a/src/main.zig
+++ b/src/main.zig
@@ -3344,21 +3344,32 @@ fn reconcileNativeSpaceCapacity() bool {
 
     while (capacity.total_count < required_count) {
         const space_id = sky.createNativeSpace(display_id) orelse {
-            log.warn("native Space creation failed display={d}", .{display_id});
+            log.warn("native Space creation failed display={d} required={d} available={d}", .{ display_id, required_count, capacity.total_count });
             return false;
         };
 
         var observed_capacity = capacity;
+        const started_ns = nanoTimestamp();
+        var unavailable_samples: u8 = 0;
         var attempt: u8 = 0;
         while (attempt < native_space_capacity_settle_attempts) : (attempt += 1) {
             _ = c.usleep(native_space_capacity_poll_delay_us);
-            observed_capacity = nativeSpaceCapacity() orelse continue;
+            observed_capacity = nativeSpaceCapacity() orelse {
+                unavailable_samples += 1;
+                continue;
+            };
             if (observed_capacity.total_count > capacity.total_count) break;
         }
         if (observed_capacity.total_count <= capacity.total_count) {
-            log.warn("created native Space did not enter managed topology display={d} space={d}", .{
+            log.warn("created native Space did not enter managed topology display={d} space={d} required={d} before={d} last_available={d} polls={d} unavailable_samples={d} elapsed_ms={d}", .{
                 display_id,
                 space_id,
+                required_count,
+                capacity.total_count,
+                observed_capacity.total_count,
+                attempt,
+                unavailable_samples,
+                @divTrunc(nanoTimestamp() - started_ns, std.time.ns_per_ms),
             });
             return false;
         }
@@ -3389,14 +3400,27 @@ fn reconcileNativeSpaceCapacity() bool {
         }
 
         var observed_capacity = capacity;
+        const started_ns = nanoTimestamp();
+        var unavailable_samples: u8 = 0;
         var attempt: u8 = 0;
         while (attempt < native_space_capacity_settle_attempts) : (attempt += 1) {
             _ = c.usleep(native_space_capacity_poll_delay_us);
-            observed_capacity = nativeSpaceCapacity() orelse continue;
+            observed_capacity = nativeSpaceCapacity() orelse {
+                unavailable_samples += 1;
+                continue;
+            };
             if (observed_capacity.total_count < capacity.total_count) break;
         }
         if (observed_capacity.total_count >= capacity.total_count) {
-            log.warn("destroyed native Space did not leave managed topology space={d}", .{space_id});
+            log.warn("destroyed native Space did not leave managed topology space={d} required={d} before={d} last_available={d} polls={d} unavailable_samples={d} elapsed_ms={d}", .{
+                space_id,
+                required_count,
+                capacity.total_count,
+                observed_capacity.total_count,
+                attempt,
+                unavailable_samples,
+                @divTrunc(nanoTimestamp() - started_ns, std.time.ns_per_ms),
+            });
             return false;
         }
 
@@ -3426,7 +3450,11 @@ fn reconcileNativeSpaceTopologyIfNeeded() void {
             capacity.total_count,
         });
         if (!reconcileNativeSpaceCapacity()) {
-            log.warn("live native Space capacity reconciliation failed", .{});
+            log.warn("live native Space capacity reconciliation failed required={d} initial_available={d} displays={d}", .{
+                workspaceCount(),
+                capacity.total_count,
+                g_display_count,
+            });
             return;
         }
         reconcileDisplays(.preserve_space_ids);
@@ -3485,7 +3513,14 @@ fn nativeTopologyFromSnapshot(snapshot: *const skylight.NativeSpaceTopology, map
             };
         }
         if (std.mem.indexOfScalar(u64, observed_display.space_ids[0..captured_count], observed_space_id) == null) {
-            log.warn("native topology: observed Space outside managed range display={d} space={d}", .{ display.id, observed_space_id });
+            log.warn("native topology: observed Space outside managed range display={d} space={d} ordinary_count={d} captured_count={d} limit={d} captured_space_ids={any}", .{
+                display.id,
+                observed_space_id,
+                available_count,
+                captured_count,
+                state_mod.max_spaces_per_display,
+                observed_display.space_ids[0..captured_count],
+            });
             return null;
         }
         observation.addDisplay(observed_display);
@@ -3498,7 +3533,7 @@ fn nativeTopologyFromSnapshot(snapshot: *const skylight.NativeSpaceTopology, map
         return null;
     }
 
-    return state_mod.mapNativeTopology(
+    const topology = state_mod.mapNativeTopology(
         observation,
         &g_state.native_topology,
         &g_state.workspace_topology,
@@ -3506,7 +3541,13 @@ fn nativeTopologyFromSnapshot(snapshot: *const skylight.NativeSpaceTopology, map
         workspaceCount(),
         primaryDisplayId(),
         mapping,
-    );
+    ) orelse {
+        log.warn("native topology: workspace mapping failed mapping={s} configured={d} captured={d} displays={d} primary_display={d}", .{
+            @tagName(mapping), workspaceCount(), captured_space_count, observation.display_count, primaryDisplayId(),
+        });
+        return null;
+    };
+    return topology;
 }
 
 fn dispatchStateEvent(event: state_mod.Event) void {
@@ -3866,31 +3907,30 @@ fn executeWindowGeometrySettled(
             const intent = observation.pending_intent orelse return;
             if (reconcileDivergedGeometryIntent(observation.window_id, intent)) return;
 
-            switch (intent.target) {
-                .frame => |target| log.warn("geometry: frame intent did not converge wid={d} source={s} target=({d:.0},{d:.0},{d:.0},{d:.0}) observed=({d:.0},{d:.0},{d:.0},{d:.0})", .{
-                    observation.window_id,
-                    @tagName(intent.source),
-                    target.x,
-                    target.y,
-                    target.width,
-                    target.height,
-                    observation.frame.x,
-                    observation.frame.y,
-                    observation.frame.width,
-                    observation.frame.height,
-                }),
-                .position => |target| log.warn("geometry: position intent did not converge wid={d} source={s} target=({d:.0},{d:.0}) observed=({d:.0},{d:.0})", .{
-                    observation.window_id,
-                    @tagName(intent.source),
-                    target.x,
-                    target.y,
-                    observation.frame.x,
-                    observation.frame.y,
-                }),
-            }
+            logUnsettledGeometry(observation, intent);
             return;
         },
         .external => handleExternalWindowGeometry(observation.window_id, observation.frame),
+    }
+}
+
+fn logUnsettledGeometry(observation: @FieldType(geometry_mod.Effect, "settled"), intent: geometry_mod.Intent) void {
+    const win = managedWindow(observation.window_id) orelse return;
+    const space = managedWindowSpace(observation.window_id) orelse return;
+    var app_buf: [256]u8 = undefined;
+    const app = osutil.appBundleId(win.pid, &app_buf) orelse "unknown";
+    switch (intent.target) {
+        .frame => |target| log.warn("geometry: frame intent did not converge wid={d} pid={d} app={s} workspace={d} display={d} source={s} generation={d} target=({d:.0},{d:.0},{d:.0},{d:.0}) observed=({d:.0},{d:.0},{d:.0},{d:.0}) delta=({d:.0},{d:.0},{d:.0},{d:.0})", .{
+            observation.window_id,          win.pid,                        app,                                    space.workspace_id,                       space.display_id,
+            @tagName(intent.source),        intent.generation,              target.x,                               target.y,                                 target.width,
+            target.height,                  observation.frame.x,            observation.frame.y,                    observation.frame.width,                  observation.frame.height,
+            observation.frame.x - target.x, observation.frame.y - target.y, observation.frame.width - target.width, observation.frame.height - target.height,
+        }),
+        .position => |target| log.warn("geometry: position intent did not converge wid={d} pid={d} app={s} workspace={d} display={d} source={s} generation={d} target=({d:.0},{d:.0}) observed=({d:.0},{d:.0}) delta=({d:.0},{d:.0})", .{
+            observation.window_id,   win.pid,                        app,                            space.workspace_id, space.display_id,
+            @tagName(intent.source), intent.generation,              target.x,                       target.y,           observation.frame.x,
+            observation.frame.y,     observation.frame.x - target.x, observation.frame.y - target.y,
+        }),
     }
 }
 

--- a/src/state.zig
+++ b/src/state.zig
@@ -42,6 +42,7 @@ pub const NativeTopology = model_mod.NativeTopology;
 pub const NativeTopologyInitialization = model_mod.NativeTopologyInitialization;
 pub const NativeDisplayObservation = model_mod.NativeDisplayObservation;
 pub const NativeTopologyObservation = model_mod.NativeTopologyObservation;
+pub const NativeTopologyMapping = model_mod.NativeTopologyMapping;
 pub const mapNativeTopology = model_mod.mapNativeTopology;
 pub const ManagedWindow = model_mod.ManagedWindow;
 pub const WindowTabGroupObservation = model_mod.WindowTabGroupObservation;
@@ -155,6 +156,7 @@ pub fn reduce(model: Model, event: Event) Transition {
             );
         },
         .initialize_native_topology => |initialization| {
+            const previous_catalog = transition.model.spaces;
             const workspace_transition = transition.model.workspace_transition;
             const requested = transition.model.queued_switch orelse if (transition.model.pending_switch) |pending| pending.request else null;
             workspace_reducer.cancelGesture(&transition);
@@ -171,6 +173,7 @@ pub fn reduce(model: Model, event: Event) Transition {
                 transition.model.deferred_follow_focus = null;
             }
             workspace_reducer.syncNativeWorkspaceTopology(&transition);
+            workspace_reducer.remapWorkspaceFocus(&transition.model, &previous_catalog);
             if (initialization.focused_display_id) |display_id| {
                 if (transition.model.workspace_topology.findDisplay(display_id) != null) {
                     transition.model.workspace_topology.focused_display_id = display_id;
@@ -242,6 +245,7 @@ pub fn reduce(model: Model, event: Event) Transition {
         .focus_retry_observed => |observation| discovery_reducer.reduceFocusRetryObserved(&transition, observation),
         .display_changed => |change| {
             transition.model.display_resettle_due_at_ms = change.resettle_at_ms;
+            transition.model.display_resettle_mapping = .native_order;
             const is_debounced = if (transition.model.last_display_change_at_ms) |previous|
                 change.at_ms < previous +| display_event_debounce_ms
             else
@@ -252,8 +256,9 @@ pub fn reduce(model: Model, event: Event) Transition {
             }
         },
         .display_resettle_timer_fired => |at_ms| workspace_reducer.reduceDisplayResettleTimer(&transition, at_ms),
-        .display_reconcile_unavailable => |at_ms| {
-            transition.model.display_resettle_due_at_ms = at_ms +| display_event_debounce_ms;
+        .display_reconcile_unavailable => |failure| {
+            transition.model.display_resettle_due_at_ms = failure.at_ms +| display_event_debounce_ms;
+            transition.model.display_resettle_mapping = failure.mapping;
         },
         .configure_layout_interaction => |configuration| {
             transition.model.bsp_split_mode = configuration.split_mode;
@@ -1194,7 +1199,7 @@ test "native topology mapping assigns one global workspace per physical slot" {
     observation.addDisplay(secondary);
 
     const previous: NativeTopology = .{};
-    const mapped = mapNativeTopology(observation, &previous, &workspace_topology, &catalog, 3, 1).?;
+    const mapped = mapNativeTopology(observation, &previous, &workspace_topology, &catalog, 3, 1, .preserve_space_ids).?;
 
     try testing.expectEqual(@as(?WorkspaceId, 1), mapped.observedWorkspace(1));
     try testing.expectEqual(@as(?WorkspaceId, 3), mapped.observedWorkspace(2));
@@ -1239,7 +1244,7 @@ test "native topology mapping ignores an activated extra Space" {
     observed_secondary.space_ids[0] = 201;
     observation.addDisplay(observed_secondary);
 
-    const mapped = mapNativeTopology(observation, &previous, &workspace_topology, &catalog, 3, 1).?;
+    const mapped = mapNativeTopology(observation, &previous, &workspace_topology, &catalog, 3, 1, .preserve_space_ids).?;
 
     try testing.expect(mapped.eql(&previous));
     try testing.expect(mapped.findDisplay(1).?.workspaceForSpace(103) == null);
@@ -1277,6 +1282,7 @@ test "initial topology mapping binds logical workspaces to physical Spaces" {
         &catalog,
         4,
         11,
+        .native_order,
     ).?;
 
     try testing.expectEqual(@as(?WorkspaceId, 2), mapped.observedWorkspace(11));
@@ -1296,6 +1302,7 @@ test "initial topology mapping binds logical workspaces to physical Spaces" {
         &catalog,
         4,
         11,
+        .native_order,
     ).?;
     var workspace_id: WorkspaceId = 1;
     while (workspace_id <= 4) : (workspace_id += 1) {
@@ -2165,7 +2172,7 @@ test "failed workspace move waits for actual rollback result" {
     try testing.expect(!transition.effects[1].native_workspace_move_failed.rollback_succeeded);
 }
 
-test "new display cannot steal surviving workspace shortcut identities" {
+test "ordinary observations preserve surviving workspace shortcut identities" {
     const testing = std.testing;
     const model = initializedModel(testTopology(101, null));
     var observation: NativeTopologyObservation = .{};
@@ -2176,10 +2183,72 @@ test "new display cannot steal surviving workspace shortcut identities" {
     old_display.space_ids[0] = 101;
     old_display.space_ids[1] = 102;
     observation.addDisplay(old_display);
-    const mapped = mapNativeTopology(observation, &model.native_topology, &model.workspace_topology, &model.spaces, 3, 2).?;
+    const mapped = mapNativeTopology(observation, &model.native_topology, &model.workspace_topology, &model.spaces, 3, 2, .preserve_space_ids).?;
     try testing.expectEqual(@as(?NativeSpaceId, 101), mapped.findDisplay(1).?.spaceForWorkspace(1));
     try testing.expectEqual(@as(?NativeSpaceId, 102), mapped.findDisplay(1).?.spaceForWorkspace(2));
     try testing.expectEqual(@as(?NativeSpaceId, 201), mapped.findDisplay(2).?.spaceForWorkspace(3));
+}
+
+test "display reconnect renumbers surviving Spaces without moving their windows or layouts" {
+    const testing = std.testing;
+    var previous: NativeTopology = .{};
+    var laptop = DisplayTopology.init(1, 102);
+    for (0..10) |index| laptop.addSpace(.{ .id = 101 + index, .workspace_id = @intCast(index + 1) });
+    previous.addDisplay(laptop);
+    var model = initializedModel(previous);
+    for ([_]WindowId{ 42, 43 }, [_]NativeSpaceId{ 102, 103 }) |wid, sid| {
+        model = reduce(model, .{ .adopt_window = .{
+            .window_id = wid,
+            .process_id = 10,
+            .space_key = .{ .id = sid },
+            .layout = testLayoutInsertion(.bsp),
+        } }).model;
+        model = reduce(model, .{ .record_workspace_focus = .{
+            .window_id = wid,
+            .workspace_id = @intCast(sid - 100),
+        } }).model;
+    }
+
+    // macOS restores the old workspace 2 on the laptop, after the nine
+    // ordinary Spaces on the newly connected primary display.
+    var observation: NativeTopologyObservation = .{};
+    var observed_laptop: NativeDisplayObservation = .{ .display_id = 1, .observed_space_id = 102, .space_count = 1 };
+    observed_laptop.space_ids[0] = 102;
+    observation.addDisplay(observed_laptop);
+    var external: NativeDisplayObservation = .{ .display_id = 2, .observed_space_id = 101, .space_count = 9 };
+    external.space_ids[0] = 101;
+    for (1..9) |index| external.space_ids[index] = 102 + index;
+    observation.addDisplay(external);
+
+    const mapped = mapNativeTopology(observation, &model.native_topology, &model.workspace_topology, &model.spaces, 10, 2, .native_order).?;
+    try testing.expectEqual(@as(?NativeSpaceId, 103), mapped.findDisplay(2).?.spaceForWorkspace(2));
+    try testing.expectEqual(@as(?NativeSpaceId, 102), mapped.findDisplay(1).?.spaceForWorkspace(10));
+    model = reduce(model, .{ .initialize_native_topology = .{ .topology = mapped } }).model;
+    try testing.expectEqual(@as(?WorkspaceId, 10), model.activeWorkspace(1));
+    try testing.expectEqual(@as(?WorkspaceId, 1), model.activeWorkspace(2));
+    try testing.expectEqual(@as(?WindowId, 42), model.focusedWorkspaceWindow(10));
+    try testing.expectEqual(@as(?WindowId, 43), model.focusedWorkspaceWindow(2));
+    for ([_]WindowId{ 42, 43 }, [_]NativeSpaceId{ 102, 103 }) |wid, sid| {
+        try testing.expectEqual(sid, model.window(wid).?.space_key.id);
+        try testing.expect(model.layout.contains(.{ .id = sid }, wid));
+    }
+    const repeated = mapNativeTopology(observation, &model.native_topology, &model.workspace_topology, &model.spaces, 10, 2, .native_order).?;
+    try testing.expect(mapped.eql(&repeated));
+}
+
+test "display resettle renumbers restored ordinals even when display identities are unchanged" {
+    const testing = std.testing;
+    const model = initializedModel(testTopology(101, null));
+    var observation: NativeTopologyObservation = .{};
+    var display: NativeDisplayObservation = .{ .display_id = 1, .observed_space_id = 102, .space_count = 3 };
+    @memcpy(display.space_ids[0..3], &[_]NativeSpaceId{ 103, 101, 102 });
+    observation.addDisplay(display);
+
+    const preserved = mapNativeTopology(observation, &model.native_topology, &model.workspace_topology, &model.spaces, 3, 1, .preserve_space_ids).?;
+    try testing.expectEqual(@as(?NativeSpaceId, 102), preserved.findDisplay(1).?.spaceForWorkspace(2));
+    const reordered = mapNativeTopology(observation, &model.native_topology, &model.workspace_topology, &model.spaces, 3, 1, .native_order).?;
+    try testing.expectEqual(@as(?NativeSpaceId, 101), reordered.findDisplay(1).?.spaceForWorkspace(2));
+    try testing.expectEqual(@as(?WorkspaceId, 3), reordered.observedWorkspace(1));
 }
 
 test "replaced native Spaces retain window and layout ownership" {
@@ -2210,8 +2279,12 @@ test "replaced native Spaces retain window and layout ownership" {
 
 test "failed display observation schedules another settle attempt" {
     const testing = std.testing;
-    const transition = reduce(initializedModel(testTopology(101, null)), .{ .display_reconcile_unavailable = 500 });
+    const transition = reduce(initializedModel(testTopology(101, null)), .{ .display_reconcile_unavailable = .{
+        .at_ms = 500,
+        .mapping = .preserve_space_ids,
+    } });
     try testing.expect(transition.model.display_resettle_due_at_ms.? > 500);
+    try testing.expectEqual(NativeTopologyMapping.preserve_space_ids, transition.model.display_resettle_mapping);
     try testing.expectEqual(@as(?WorkspaceId, 1), transition.model.activeWorkspace(1));
 }
 

--- a/src/state/model.zig
+++ b/src/state/model.zig
@@ -44,6 +44,7 @@ pub const NativeTopology = topology_mod.NativeTopology;
 pub const NativeTopologyInitialization = topology_mod.NativeTopologyInitialization;
 pub const NativeDisplayObservation = topology_mod.NativeDisplayObservation;
 pub const NativeTopologyObservation = topology_mod.NativeTopologyObservation;
+pub const NativeTopologyMapping = topology_mod.NativeTopologyMapping;
 pub const mapNativeTopology = topology_mod.mapNativeTopology;
 pub const ManagedWindow = window_catalog_mod.ManagedWindow;
 pub const WindowTabGroupObservation = window_catalog_mod.WindowTabGroupObservation;
@@ -646,6 +647,7 @@ pub const Model = struct {
     app_launch_retries: ProcessRetries = .{},
     focus_retries: ProcessRetries = .{},
     display_resettle_due_at_ms: ?TimestampMs = null,
+    display_resettle_mapping: NativeTopologyMapping = .native_order,
     bsp_split_mode: tiling_mod.SplitMode = .auto,
     bsp_insert_point: tiling_mod.InsertionPointPolicy = .focused,
     pointer_drag: PointerDragState = .{},
@@ -981,7 +983,10 @@ pub const Event = union(enum) {
         succeeded: bool,
         at_ms: TimestampMs = 0,
     },
-    display_reconcile_unavailable: TimestampMs,
+    display_reconcile_unavailable: struct {
+        at_ms: TimestampMs,
+        mapping: NativeTopologyMapping,
+    },
     window_focus_observed: WindowFocusObservation,
     request_pending_focus,
     follow_focus_observed: FollowFocusObservation,

--- a/src/state/reducer/workspace.zig
+++ b/src/state/reducer/workspace.zig
@@ -991,6 +991,18 @@ pub fn sameRequest(left: SwitchRequest, right: SwitchRequest) bool {
     return left.target.key.eql(right.target.key);
 }
 
+/// Renumbering a surviving Space must carry its focus history with its windows.
+/// Replaced Spaces still inherit the history of their logical workspace.
+pub fn remapWorkspaceFocus(model: *Model, previous_catalog: *const SpaceCatalog) void {
+    const previous_focus = model.workspace_focus;
+    model.workspace_focus = @splat(.{});
+    for (model.spaces.spaces[0..model.spaces.space_count]) |space| {
+        const previous = previous_catalog.find(space.key) orelse
+            previous_catalog.findLogicalWorkspace(space.workspace_id) orelse continue;
+        model.workspace_focus[space.workspace_id - 1] = previous_focus[previous.workspace_id - 1];
+    }
+}
+
 pub fn refreshWorkspaceFocus(model: *Model) void {
     for (&model.workspace_focus, 0..) |*focus, index| {
         const had_focus = focus.focused_window_id != null;

--- a/src/state/topology.zig
+++ b/src/state/topology.zig
@@ -238,6 +238,12 @@ pub const NativeTopologyObservation = struct {
     }
 };
 
+/// Display changes rebuild ordinal numbering; ordinary observations preserve it.
+pub const NativeTopologyMapping = enum {
+    preserve_space_ids,
+    native_order,
+};
+
 /// Assign global logical workspaces to an observed physical Space topology.
 pub fn mapNativeTopology(
     observation: NativeTopologyObservation,
@@ -246,13 +252,17 @@ pub fn mapNativeTopology(
     catalog: *const SpaceCatalog,
     workspace_count: u8,
     primary_display_id: DisplayId,
+    mapping: NativeTopologyMapping,
 ) ?NativeTopology {
     if (workspace_count == 0 or observation.display_count > workspace_count) return null;
     if (!observationContainsDisplay(&observation, primary_display_id)) return null;
-    if (preserveStableNativeTopology(&observation, previous, workspace_count)) |topology| return topology;
-    if (previous.display_count == 0 and catalog.space_count == 0) {
-        return mapInitialTopology(observation, workspace_count, primary_display_id);
+    // Reconnecting displays can restore old Space IDs at different ordinals.
+    // Display reconciliation explicitly renumbers them; ordinary observations
+    // preserve identities so switching or moving a workspace cannot renumber it.
+    if (mapping == .native_order or (previous.display_count == 0 and catalog.space_count == 0)) {
+        return mapTopologyInNativeOrder(observation, workspace_count, primary_display_id);
     }
+    if (preserveStableNativeTopology(&observation, previous, workspace_count)) |topology| return topology;
 
     var assignments: [max_displays][max_spaces_per_display]WorkspaceId = @splat(@splat(0));
     var claimed: [max_spaces_per_display + 1]bool = @splat(false);
@@ -317,7 +327,7 @@ pub fn mapNativeTopology(
     return topology;
 }
 
-fn mapInitialTopology(
+fn mapTopologyInNativeOrder(
     observation: NativeTopologyObservation,
     workspace_count: WorkspaceId,
     primary_display_id: DisplayId,


### PR DESCRIPTION
Two improvements:
- Improves geometry and native Space warnings with app, workspace, and failure context. 
- Fixes workspace numbering after display reconnects to follow Mission Control order while preserving windows, layouts, and focus.
